### PR TITLE
Deltas fix

### DIFF
--- a/src/features/Chat.tsx
+++ b/src/features/Chat.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from "react";
+import React, { useCallback, useMemo, useRef } from "react";
 import { ChatForm } from "../components/ChatForm";
 import { useEventBusForChat } from "../hooks/useEventBusForChat";
 import { ChatContent } from "../components/ChatContent";
@@ -62,6 +62,17 @@ export const Chat: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
     if (maybeTools && maybeTools.length > 0) return true;
     return false;
   }, [state.chat.messages]);
+
+  const onTextAreaHeightChange = useCallback(() => {
+    if (!chatContentRef.current) return;
+    // TODO: handle preventing scroll if the user is not on the bottom of the chat
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    chatContentRef.current.scrollIntoView &&
+      chatContentRef.current.scrollIntoView({
+        behavior: "instant",
+        block: "end",
+      });
+  }, [chatContentRef]);
 
   return (
     <PageWrapper host={host} style={style}>
@@ -136,16 +147,7 @@ export const Chat: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
         filesInPreview={state.files_in_preview}
         selectedSnippet={state.selected_snippet}
         removePreviewFileByName={removePreviewFileByName}
-        onTextAreaHeightChange={() => {
-          if (!chatContentRef.current) return;
-          // TODO: handle preventing scroll if the user is not on the bottom of the chat
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-          chatContentRef.current.scrollIntoView &&
-            chatContentRef.current.scrollIntoView({
-              behavior: "instant",
-              block: "end",
-            });
-        }}
+        onTextAreaHeightChange={onTextAreaHeightChange}
         requestCaps={maybeRequestCaps}
         prompts={state.system_prompts.prompts}
         onSetSystemPrompt={setSelectedSystemPrompt}

--- a/src/hooks/useEventBusForChat/index.ts
+++ b/src/hooks/useEventBusForChat/index.ts
@@ -196,7 +196,7 @@ export function reducer(postMessage: typeof window.postMessage) {
       postMessage(notes);
     }
 
-    console.log(action.type, { isThisChat, action });
+    // console.log(action.type, { isThisChat, action });
     // console.log(action.payload);
 
     if (isThisChat && isSetDisableChat(action)) {

--- a/src/hooks/useEventBusForChat/index.ts
+++ b/src/hooks/useEventBusForChat/index.ts
@@ -196,7 +196,7 @@ export function reducer(postMessage: typeof window.postMessage) {
       postMessage(notes);
     }
 
-    // console.log(action.type, { isThisChat, action });
+    console.log(action.type, { isThisChat, action });
     // console.log(action.payload);
 
     if (isThisChat && isSetDisableChat(action)) {
@@ -230,6 +230,9 @@ export function reducer(postMessage: typeof window.postMessage) {
 
     if (!isThisChat && isResponseToChat(action)) {
       if (!(action.payload.id in state.chat_cache)) {
+        return state;
+      }
+      if (isChatUserMessageResponse(action.payload)) {
         return state;
       }
 

--- a/src/hooks/useEventBusForChat/reducer.test.ts
+++ b/src/hooks/useEventBusForChat/reducer.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "vitest";
+import { v4 as uuidv4 } from "uuid";
 import { reducer, createInitialState } from ".";
-import { EVENT_NAMES_TO_CHAT, ToolCall, ResponseToChat } from "../../events";
+import {
+  EVENT_NAMES_TO_CHAT,
+  ToolCall,
+  ResponseToChat,
+  ActionToChat,
+} from "../../events";
 import { mergeToolCalls } from "./utils";
 
 describe("reducer", () => {
@@ -68,5 +74,72 @@ describe("mergeToolCalls", () => {
     const result = mergeToolCalls(stored, toAdd);
 
     expect(result).toEqual(expected);
+  });
+});
+
+describe("cache", () => {
+  test("loading the cache correctly", () => {
+    const initialState = createInitialState();
+    const chat1id = uuidv4();
+    const chat2id = uuidv4();
+
+    function create_restore_chat(
+      fromId: string,
+      toId: string,
+      message: string,
+    ) {
+      return {
+        type: EVENT_NAMES_TO_CHAT.RESTORE_CHAT,
+        payload: {
+          id: fromId,
+          chat: {
+            messages: [["user", message]],
+            model: "gpt-3.5-turbo",
+            id: toId,
+          },
+        },
+      };
+    }
+
+    function create_chat_response(id: string, message: string) {
+      return {
+        type: EVENT_NAMES_TO_CHAT.CHAT_RESPONSE,
+        payload: {
+          id,
+          choices: [
+            {
+              delta: {
+                content: message,
+                role: "assistant",
+              },
+              finish_reason: null,
+              index: 0,
+            },
+          ],
+          created: 1710777171.188,
+          model: "gpt-3.5-turbo",
+        },
+      };
+    }
+
+    const actions: ActionToChat[] = [
+      create_restore_chat(initialState.chat.id, chat1id, "Hello"),
+      create_chat_response(chat1id, "test"),
+      create_restore_chat(chat1id, chat2id, "Goodbye"),
+      create_chat_response(chat1id, " response"),
+      create_restore_chat(chat2id, chat1id, "Test"),
+    ];
+
+    expect(() => {
+      const reduce = reducer(window.postMessage);
+      let state = initialState;
+      for (const action of actions) {
+        state = reduce(state, action);
+      }
+      expect(state.chat.messages).toEqual([
+        ["user", "Hello"],
+        ["assistant", "test response", undefined],
+      ]);
+    }).not.toThrow();
   });
 });


### PR DESCRIPTION
When a chat that’s is streaming has been moved away from, it could be added to a temporary storage where it can continue to receive updates, then when it’s done it can be save thought the history mechanism of the ide, and restored as normal.

… when restoring I guess we’ll need to check if the chat is in temporary storage and use that one if not then take the one given to it by the ide.

rough outline.

- if the chat is streaming, and another is restored / created. put it into a cache.
- if a chat response message comes in and it’s not for the current chat, check the cache if it’s there then add the stream to it.
- do a similar check for the done message, but send a save history event and remove the cached chat.
- When restoring / switching between chats, check the cache first