### PR TITLE
Fix: Login procedure not breakes up anymore on PRO tier selected

### DIFF
--- a/src/components/CloudLogin/CloudLogin.tsx
+++ b/src/components/CloudLogin/CloudLogin.tsx
@@ -76,7 +76,7 @@ export const CloudLogin: React.FC<CloudLoginProps> = ({
       <Text size="3">Already have a Refact.ai account?</Text>
       <Button
         ref={loginButton}
-        onClick={() => onLogin("free")}
+        onClick={() => onLogin(selected)}
         color="gray"
         highContrast
         variant="solid"


### PR DESCRIPTION
# Fix: Login procedure not breakes up anymore on PRO tier selected

## Description
PRO tier was not selectable and login procedure was stopping each time we are trying to change a plan.
I've removed hardcoded part in `CloudLogin.tsx` component, Button's `onClick` function.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test
<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->
- Step 1: Start refact-lsp
- Step 2: Start refact-chat-js
- Step 3: Choose Refact Cloud as Setup Option
- Step 4: Choose between FREE or PRO tiers.