### PR TITLE
Fix: Tour Bubble size limitation

### DIFF
--- a/src/components/Tour/Tour.tsx
+++ b/src/components/Tour/Tour.tsx
@@ -69,6 +69,9 @@ export const Tour: React.FC<TourProps> = ({ page }) => {
         page={page}
         onNext={openChat}
         containerWidth={chatWidth}
+        bubbleContainerStyles={{
+          alignSelf: "flex-end",
+        }}
       />
       <TourBubble
         text={
@@ -80,6 +83,9 @@ export const Tour: React.FC<TourProps> = ({ page }) => {
         containerWidth={chatWidth}
         onPage={"chat"}
         page={page}
+        bubbleContainerStyles={{
+          alignSelf: "flex-start",
+        }}
       />
       <TourBubble
         text={
@@ -91,6 +97,9 @@ export const Tour: React.FC<TourProps> = ({ page }) => {
         containerWidth={chatWidth}
         onPage={"chat"}
         page={page}
+        bubbleContainerStyles={{
+          alignSelf: "flex-start",
+        }}
       />
       <TourBubble
         text={
@@ -102,6 +111,10 @@ export const Tour: React.FC<TourProps> = ({ page }) => {
         containerWidth={chatWidth}
         onPage={"chat"}
         page={page}
+        bubbleContainerStyles={{
+          maxWidth: 550,
+          alignSelf: "center",
+        }}
       />
       <TourBubble
         text={
@@ -114,6 +127,9 @@ export const Tour: React.FC<TourProps> = ({ page }) => {
         onPage={"chat"}
         page={page}
         onNext={openHistory}
+        bubbleContainerStyles={{
+          alignSelf: "flex-start",
+        }}
       />
       <TourBubble
         text={
@@ -125,6 +141,9 @@ export const Tour: React.FC<TourProps> = ({ page }) => {
         target={refs.more}
         onPage={"history"}
         page={page}
+        bubbleContainerStyles={{
+          alignSelf: "flex-end",
+        }}
       />
     </>
   );

--- a/src/components/Tour/TourBox.tsx
+++ b/src/components/Tour/TourBox.tsx
@@ -20,6 +20,7 @@ export function TourBox({ children, style }: TourBubbleProps) {
         justifyContent: "center",
         padding: "10px",
         alignSelf: "stretch",
+        maxWidth: 550,
         ...style,
       }}
     >

--- a/src/components/Tour/TourBubble.tsx
+++ b/src/components/Tour/TourBubble.tsx
@@ -5,7 +5,7 @@ import { close, next } from "../../features/Tour";
 import { useWindowDimensions } from "../../hooks/useWindowDimensions";
 import { TourBox } from "./TourBox";
 import { TourTitle } from "./TourTitle";
-import { ReactNode, useEffect, useState } from "react";
+import { CSSProperties, ReactNode, useEffect, useState } from "react";
 
 export type TourBubbleProps = {
   text: string;
@@ -19,6 +19,7 @@ export type TourBubbleProps = {
   deltaY?: number;
   children?: ReactNode;
   onNext?: () => void;
+  bubbleContainerStyles?: CSSProperties;
 };
 
 export function TourBubble({
@@ -33,6 +34,7 @@ export function TourBubble({
   deltaY,
   children,
   onNext,
+  bubbleContainerStyles,
 }: TourBubbleProps) {
   const dispatch = useAppDispatch();
   const state = useAppSelector((state: RootState) => state.tour);
@@ -130,7 +132,7 @@ export function TourBubble({
               }}
             />
           )}
-          <TourBox>
+          <TourBox style={bubbleContainerStyles}>
             <TourTitle title={text} />
             {children}
             <Link


### PR DESCRIPTION
# Fix: Tour Bubble size limitation

## Description
- Problem: Current Tour Bubbles are stretching of insane dimensions on wide areas of view.
- Solution: Adjustment of TourBox component and Tour component itself. Implementation of `bubbleContainerStyles` to control position and behavior of exact Tour Bubble and limit its width to 550 pixels.
- [Any background context or related links?](https://github.com/orgs/smallcloudai/projects/5/views/1?pane=issue&itemId=75268877)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test
- Step 1: Click on Menu icon at top right corner
- Step 2: Click on `Restart Tour` button
- Step 3: Click `Next` button on each Bubble to move to the next Bubble.

## Screenshots
### Top right corner
![Top right corner](https://i.imgur.com/koz0O7I.png)
### Bottom left corner
![Bottom left corner](https://i.imgur.com/TCGs0TY.png)

## Checklist
<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.