### PR TITLE
Fix: Type @ for commands hint

### DIFF
--- a/src/components/ChatForm/ChatForm.tsx
+++ b/src/components/ChatForm/ChatForm.tsx
@@ -204,7 +204,7 @@ export const ChatForm: React.FC<ChatFormProps> = ({
               handleEnter(event);
             }}
             placeholder={
-              commands.completions.length > 0 ? "Type @ for commands" : ""
+              commands.completions.length < 1 ? "Type @ for commands" : ""
             }
             render={(props) => (
               <TextArea


### PR DESCRIPTION
# Fix: Type @ for commands hint

## Description

- Problem: Hint is disappearing even if textarea is empty and `completion.commands` array is empty.
- Solution: Fix of condition for placeholder render.
- [Any background context or related links?](https://github.com/orgs/smallcloudai/projects/5/views/1?pane=issue&itemId=70283681)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

- Step 1: Start a New Chat
- Step 2: "Type @ for commands" hint should be already visible
- Step 3: Try to write some commands or text
- Step 4: Make textarea clear again
- Step 5: Hint should be visible

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.