### PR TITLE
wip(ping): add ping service and hook.

### DIFF
--- a/src/__tests__/ChatCapsFetchError.test.tsx
+++ b/src/__tests__/ChatCapsFetchError.test.tsx
@@ -1,7 +1,13 @@
 import { render, waitFor } from "../utils/test-utils";
 import { describe, expect, test } from "vitest";
 import { HttpResponse, http } from "msw";
-import { server, goodPrompts, noTools, goodUser } from "../utils/mockServer";
+import {
+  server,
+  goodPrompts,
+  noTools,
+  goodUser,
+  goodPing,
+} from "../utils/mockServer";
 import { Chat } from "../features/Chat";
 
 describe("chat caps error", () => {
@@ -9,6 +15,7 @@ describe("chat caps error", () => {
     const errorMessage =
       "500 Internal Server Error caps fetch failed: failed to open file 'hren'";
     server.use(
+      goodPing,
       noTools,
       goodPrompts,
       goodUser,

--- a/src/__tests__/DeleteChat.test.tsx
+++ b/src/__tests__/DeleteChat.test.tsx
@@ -1,11 +1,11 @@
 import { render } from "../utils/test-utils";
 import { describe, expect, it } from "vitest";
-import { server, goodUser } from "../utils/mockServer";
+import { server, goodUser, goodPing } from "../utils/mockServer";
 import { InnerApp } from "../features/App";
 import { HistoryState } from "../features/History/historySlice";
 
 describe("Delete a Chat form history", () => {
-  server.use(goodUser);
+  server.use(goodUser, goodPing);
   it("can delete a chat", async () => {
     const now = new Date().toISOString();
     const history: HistoryState = {

--- a/src/__tests__/RestoreChat.test.tsx
+++ b/src/__tests__/RestoreChat.test.tsx
@@ -8,12 +8,14 @@ import {
   noCommandPreview,
   noCompletions,
   goodUser,
+  goodPing,
 } from "../utils/mockServer";
 import { InnerApp } from "../features/App";
 
 describe("Restore Chat from history", () => {
   test("Restore chat from history", async () => {
     server.use(
+      goodPing,
       goodCaps,
       goodPrompts,
       noTools,

--- a/src/__tests__/StartNewChat.test.tsx
+++ b/src/__tests__/StartNewChat.test.tsx
@@ -8,11 +8,13 @@ import {
   noCommandPreview,
   noCompletions,
   goodUser,
+  goodPing,
 } from "../utils/mockServer";
 import { InnerApp } from "../features/App";
 
 describe("Start a new chat", () => {
   server.use(
+    goodPing,
     goodCaps,
     goodPrompts,
     noTools,

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -21,6 +21,7 @@ import {
   toolsApi,
   commandsApi,
   diffApi,
+  pingApi,
 } from "../services/refact";
 import { smallCloudApi } from "../services/smallcloud";
 import { reducer as fimReducer } from "../features/FIM/reducer";
@@ -58,6 +59,7 @@ const rootReducer = combineSlices(
     [commandsApi.reducerPath]: commandsApi.reducer,
     [diffApi.reducerPath]: diffApi.reducer,
     [smallCloudApi.reducerPath]: smallCloudApi.reducer,
+    [pingApi.reducerPath]: pingApi.reducer,
   },
   historySlice,
   errorSlice,
@@ -98,6 +100,7 @@ export function setUpStore(preloadedState?: Partial<RootState>) {
           },
         })
           .concat(
+            pingApi.middleware,
             statisticsApi.middleware,
             capsApi.middleware,
             promptsApi.middleware,

--- a/src/components/ChatForm/ChatForm.test.tsx
+++ b/src/components/ChatForm/ChatForm.test.tsx
@@ -11,6 +11,7 @@ import {
   noTools,
   noCommandPreview,
   noCompletions,
+  goodPing,
 } from "../../utils/mockServer";
 
 const handlers = [
@@ -19,6 +20,7 @@ const handlers = [
   noTools,
   noCommandPreview,
   noCompletions,
+  goodPing,
 ];
 
 server.use(...handlers);

--- a/src/features/Chat/Chat.test.tsx
+++ b/src/features/Chat/Chat.test.tsx
@@ -42,6 +42,7 @@ import {
   noCommandPreview,
   noCompletions,
   goodUser,
+  goodPing,
 } from "../../utils/mockServer";
 
 const handlers = [
@@ -51,6 +52,7 @@ const handlers = [
   noCommandPreview,
   noCompletions,
   goodUser,
+  goodPing,
 ];
 
 // const handlers = [
@@ -244,7 +246,14 @@ describe("Chat", () => {
   it.skip("when creating a new chat I can select which model to use", async () => {
     // Missing props in jsdom
     // window.PointerEvent = class PointerEvent extends Event {};
-    server.use(goodPrompts, noCommandPreview, noCompletions, noTools, goodCaps);
+    server.use(
+      goodPrompts,
+      noCommandPreview,
+      noCompletions,
+      noTools,
+      goodCaps,
+      goodPing,
+    );
     const chatSpy = vi.fn();
     server.use(
       http.post("http://127.0.0.1:8001/v1/chat", (req) => {
@@ -357,6 +366,7 @@ describe("Chat", () => {
   it("chat error streaming", async () => {
     const encoder = new TextEncoder();
     server.use(
+      goodPing,
       goodPrompts,
       noCommandPreview,
       goodCaps,

--- a/src/hooks/useGetCapsQuery.ts
+++ b/src/hooks/useGetCapsQuery.ts
@@ -1,8 +1,11 @@
 import { useAppSelector } from "./useAppSelector";
 import { getErrorMessage } from "../features/Errors/errorsSlice";
 import { capsApi } from "../services/refact/caps";
+import { useGetPing } from "./useGetPing";
 
 export const useGetCapsQuery = () => {
   const error = useAppSelector(getErrorMessage);
-  return capsApi.useGetCapsQuery(undefined, { skip: !!error });
+  const pong = useGetPing();
+  const skip = !!error || !pong.data;
+  return capsApi.useGetCapsQuery(undefined, { skip });
 };

--- a/src/hooks/useGetPing.ts
+++ b/src/hooks/useGetPing.ts
@@ -1,5 +1,5 @@
 import { pingApi } from "../services/refact";
 
-export const usePing = () => {
+export const useGetPing = () => {
   return pingApi.usePingQuery(undefined);
 };

--- a/src/hooks/useGetPromptsQuery.ts
+++ b/src/hooks/useGetPromptsQuery.ts
@@ -1,8 +1,12 @@
 import { useAppSelector } from "./useAppSelector";
 import { getErrorMessage } from "../features/Errors/errorsSlice";
 import { promptsApi } from "../services/refact/prompts";
+import { useGetPing } from "./useGetPing";
 
 export const useGetPromptsQuery = () => {
   const error = useAppSelector(getErrorMessage);
-  return promptsApi.useGetPromptsQuery(undefined, { skip: !!error });
+  const ping = useGetPing();
+  const skip = !!error || !ping.data;
+
+  return promptsApi.useGetPromptsQuery(undefined, { skip });
 };

--- a/src/hooks/useGetStatisticDataQuery.ts
+++ b/src/hooks/useGetStatisticDataQuery.ts
@@ -1,5 +1,8 @@
 import { statisticsApi } from "../services/refact/statistics";
+import { useGetPing } from "./useGetPing";
 
 export const useGetStatisticDataQuery = () => {
-  return statisticsApi.useGetStatisticDataQuery(undefined);
+  const ping = useGetPing();
+  const skip = !ping.data;
+  return statisticsApi.useGetStatisticDataQuery(undefined), { skip };
 };

--- a/src/hooks/useGetStatisticDataQuery.ts
+++ b/src/hooks/useGetStatisticDataQuery.ts
@@ -4,5 +4,5 @@ import { useGetPing } from "./useGetPing";
 export const useGetStatisticDataQuery = () => {
   const ping = useGetPing();
   const skip = !ping.data;
-  return statisticsApi.useGetStatisticDataQuery(undefined), { skip };
+  return statisticsApi.useGetStatisticDataQuery(undefined, { skip });
 };

--- a/src/hooks/usePing.ts
+++ b/src/hooks/usePing.ts
@@ -1,0 +1,5 @@
+import { pingApi } from "../services/refact";
+
+export const usePing = () => {
+  return pingApi.usePingQuery(undefined);
+};

--- a/src/services/refact/consts.ts
+++ b/src/services/refact/consts.ts
@@ -13,3 +13,4 @@ export const CONFIG_PATH_URL = "/v1/config-path";
 export const DOCUMENTATION_LIST = `/v1/docs-list`;
 export const DOCUMENTATION_ADD = `/v1/docs-add`;
 export const DOCUMENTATION_REMOVE = `/v1/docs-remove`;
+export const PING_URL = `/v1/ping`;

--- a/src/services/refact/index.ts
+++ b/src/services/refact/index.ts
@@ -7,3 +7,4 @@ export * from "./statistics";
 export * from "./tools";
 export * from "./types";
 export * from "./diffs";
+export * from "./ping";

--- a/src/services/refact/ping.ts
+++ b/src/services/refact/ping.ts
@@ -1,0 +1,55 @@
+import { RootState } from "../../app/store";
+import { PING_URL } from "./consts";
+import {
+  createApi,
+  fetchBaseQuery,
+  FetchBaseQueryError,
+} from "@reduxjs/toolkit/query/react";
+
+export const pingApi = createApi({
+  reducerPath: "pingApi",
+  baseQuery: fetchBaseQuery({ baseUrl: PING_URL }),
+  tagTypes: ["PING"],
+  endpoints: (builder) => ({
+    ping: builder.query<string, undefined>({
+      providesTags: () => ["PING"],
+      queryFn: async (_arg, api, _extraOptions, _baseQuery) => {
+        const port = (api.getState() as RootState).config.lspPort;
+        const url = `http://127.0.0.1:${port}${PING_URL}`;
+        return new Promise((resolve, _reject) => {
+          const poll = () => {
+            fetch(url, {
+              method: "GET",
+              redirect: "follow",
+              cache: "no-cache",
+            })
+              .then((res) => {
+                if (res.ok) return res.text();
+                throw new Error(res.statusText);
+              })
+              .then((pong) => {
+                resolve({ data: pong });
+              })
+              .catch((err: Error) => {
+                if (err.message === "Failed to fetch") {
+                  setTimeout(poll, 1000);
+                } else {
+                  const result: FetchBaseQueryError = {
+                    status: "FETCH_ERROR",
+                    error: err.message,
+                  };
+
+                  resolve({ error: result });
+                }
+              });
+          };
+          poll();
+        });
+      },
+    }),
+    reset: builder.mutation<null, undefined>({
+      queryFn: () => ({ data: null }),
+      invalidatesTags: ["PING"],
+    }),
+  }),
+});

--- a/src/utils/mockServer.ts
+++ b/src/utils/mockServer.ts
@@ -10,6 +10,7 @@ import {
   promptsApi,
   toolsApi,
   commandsApi,
+  pingApi,
 } from "../services/refact";
 
 export const resetApi = (store: Store) => {
@@ -18,6 +19,7 @@ export const resetApi = (store: Store) => {
   store.dispatch(promptsApi.util.resetApiState());
   store.dispatch(toolsApi.util.resetApiState());
   store.dispatch(commandsApi.util.resetApiState());
+  store.dispatch(pingApi.util.resetApiState());
 };
 export const server = setupServer();
 
@@ -35,6 +37,13 @@ afterAll(() => {
   // Clean up once the tests are done.
   server.close();
 });
+
+export const goodPing: HttpHandler = http.get(
+  "http://127.0.0.1:8001/v1/ping",
+  () => {
+    return HttpResponse.text("pong");
+  },
+);
 
 export const goodCaps: HttpHandler = http.get(
   "http://127.0.0.1:8001/v1/caps",


### PR DESCRIPTION
# Fix: Querying the lsp before it's running

## Description

- After logging in in an ide, the lsp restarts, chat can make calls to the lsp before it has had the chance to start.
- Added a call to `/v1/ping`, this will be used to skip other requests until ping works.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->

1. Build chat,
2. link it to vscode
3. logout
4. login
5. click new chat.

Or: when running in dev
1. run `npm run dev`
2. Open the network tab
3. stop the lsp.
4. refresh
5. click new chat.
Only `ping` should be called.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.

## Linked Issues
https://github.com/orgs/smallcloudai/projects/5/views/1?pane=issue&itemId=78627164

## Additional Notes

