### PR TITLE
Fix: Select scroll behavior

### DIFF
--- a/src/components/ChatForm/PromptSelect.tsx
+++ b/src/components/ChatForm/PromptSelect.tsx
@@ -8,6 +8,7 @@ export type PromptSelectProps = {
   onChange: (value: SystemPrompts) => void;
   prompts: SystemPrompts;
   disabled?: boolean;
+  contentPosition?: "item-aligned" | "popper";
 };
 
 export const PromptSelect: React.FC<PromptSelectProps> = ({
@@ -15,6 +16,7 @@ export const PromptSelect: React.FC<PromptSelectProps> = ({
   prompts,
   onChange,
   disabled,
+  contentPosition,
 }) => {
   // TODO: just use the hooks here
   const promptKeysAndValues = Object.entries(prompts);
@@ -41,7 +43,7 @@ export const PromptSelect: React.FC<PromptSelectProps> = ({
         size="1"
       >
         <Trigger title={val} />
-        <Content>
+        <Content position={contentPosition ? contentPosition : "popper"}>
           {Object.entries(prompts).map(([key, value]) => {
             return (
               <Item

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -45,7 +45,7 @@ export const Select: React.FC<SelectProps> = ({
   return (
     <Root {...props} onValueChange={onChange} size="1">
       <Trigger title={title} />
-      <Content>
+      <Content position="popper">
         {options.map((option) => {
           return (
             <Item key={option} value={option}>

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -7,6 +7,7 @@ export type SelectProps = React.ComponentProps<typeof RadixSelect.Root> & {
   onChange: (value: string) => void;
   options: string[];
   title?: string;
+  contentPosition?: "item-aligned" | "popper";
 };
 
 export type SelectRootProps = React.ComponentProps<typeof RadixSelect.Root>;
@@ -40,12 +41,13 @@ export const Select: React.FC<SelectProps> = ({
   title,
   options,
   onChange,
+  contentPosition,
   ...props
 }) => {
   return (
     <Root {...props} onValueChange={onChange} size="1">
       <Trigger title={title} />
-      <Content position="popper">
+      <Content position={contentPosition ? contentPosition : "popper"}>
         {options.map((option) => {
           return (
             <Item key={option} value={option}>

--- a/src/components/Select/select.module.css
+++ b/src/components/Select/select.module.css
@@ -9,4 +9,5 @@
   /* JB doesn't support dvw yet */
   max-width: 50vw;
   max-width: 80dvw;
+  max-height: 200px;
 }


### PR DESCRIPTION
# Fix: Select scroll behavior

## Description
- Problem: Strange scrolling behavior of a select if there are more options to choose and they don't feet inside of screen boundaries.
- Solution: Change position type to `popper` and added ability to customize it in other selects if needed.
- [Any background context or related links?](https://github.com/orgs/smallcloudai/projects/5/views/1?filterQuery=alashchev17&pane=issue&itemId=75269274)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

- Step 1: Start a New Chat
- Step 2: Choose either a model or system prompt settings within a select

## Screenshots

### Model Selection
![Model Selection](https://i.imgur.com/ROllhmy.png)

### System Prompt Selection
![System Prompt Selection](https://i.imgur.com/4ZSiyAt.png)


## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.