### PR TITLE
Fix: Prevent ChatForm from rerendering

### DIFF
--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -141,7 +141,7 @@ export const Chat: React.FC<ChatProps> = ({
       <ChatForm
         // todo: find a way to not have to stringify the whole caps object
         // the reason is that otherwise the tour bubbles will be in the wrong position due to layout shifts
-        key={`chat-form-${chatId}-${JSON.stringify(caps)}`}
+        // key={`chat-form-${chatId}-${JSON.stringify(caps)}`}
         chatId={chatId}
         isStreaming={isStreaming}
         showControls={messages.length === 0 && !isStreaming}


### PR DESCRIPTION
# Fix: Prevent ChatForm from rerendering

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- While opening a chat using F1 or just straight clicking on "New Chat", there is a delay when actual content can be written inside of a textarea, because we are waiting for caps to load to prevent layout shift.
- Since TourBubble is waiting for caps to be fetched, we can remove a key prop of component to prevent its rerender and as a result, data loss.
- [Any background context or related links?](https://github.com/orgs/smallcloudai/projects/5/views/1?filterQuery=alashchev&pane=issue&itemId=78607867)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->

- Step 1: Open your editor
- Step 2: Press F1 inside of a code
- Step 3: See how textarea behaves now

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.