### PR TITLE
Diff code block

### DIFF
--- a/src/components/Markdown/CodeBlock.tsx
+++ b/src/components/Markdown/CodeBlock.tsx
@@ -10,8 +10,8 @@ import styles from "./Markdown.module.css";
 import type { Element } from "hast";
 import hljsStyle from "react-syntax-highlighter/dist/esm/styles/hljs/agate";
 import { trimIndent } from "../../utils";
-import { DiffChunk } from "../../services/refact/types";
 import { useDiffPreview } from "../../hooks";
+import { convertMarkdownToDiffChunk } from "./convertMarkdownToDiffChunk";
 
 export type MarkdownControls = {
   onCopyClick: (str: string) => void;
@@ -19,45 +19,6 @@ export type MarkdownControls = {
   onPasteClick: (str: string) => void;
   canPaste: boolean;
 };
-
-function convertMarkdownToDiffChunk(markdown: string): DiffChunk {
-  const lines = markdown.split("\n");
-  let fileName = "";
-  let fileAction = ""; // file_action must be one of `edit, add, rename, remove`
-  let line1 = 0;
-  let line2 = 0;
-  let linesRemove = "";
-  let linesAdd = "";
-
-  lines.forEach((line) => {
-    if (line.startsWith("--- ")) {
-      fileName = line.substring(4).trim(); // Extract file name from the line
-      fileAction = "remove"; // Action for the original file
-    } else if (line.startsWith("+++ ")) {
-      fileName = line.substring(4).trim(); // Extract file name from the line
-      fileAction = fileAction === "remove" ? "edit" : "add"; // Action for the new file
-    } else if (line.startsWith("@@ ")) {
-      const parts = line.match(/@@ -(\d+),\d+ \+(\d+),\d+ @@/);
-      if (parts) {
-        line1 = parseInt(parts[1], 10); // Starting line number for the original file
-        line2 = parseInt(parts[2], 10); // Starting line number for the new file
-      }
-    } else if (line.startsWith("-")) {
-      linesRemove += line.substring(1).trim() + "\n"; // Lines removed
-    } else if (line.startsWith("+")) {
-      linesAdd += line.substring(1).trim() + "\n"; // Lines added
-    }
-  });
-
-  return {
-    file_name: fileName,
-    file_action: fileAction,
-    line1: line1,
-    line2: line2,
-    lines_remove: linesRemove.trim(),
-    lines_add: linesAdd.trim(),
-  };
-}
 
 function useDiff(language: string, markdown: string) {
   const isDiff = language === "language-diff";

--- a/src/components/Markdown/convertMarkdownToDiffChunk.ts
+++ b/src/components/Markdown/convertMarkdownToDiffChunk.ts
@@ -1,0 +1,50 @@
+import { DiffChunk } from "../../services/refact/types";
+
+export function convertMarkdownToDiffChunk(markdown: string): DiffChunk {
+  const lines = markdown.split("\n");
+  let fileName = "";
+  let fileAction: "edit" | "add" | "rename" | "remove" = "remove"; // Default to remove
+  let line1 = 0;
+  let line2 = 0;
+  let linesRemove = "";
+  let linesAdd = "";
+
+  let originalFileName = "";
+  let newFileName = "";
+
+  lines.forEach((line) => {
+    if (line.startsWith("--- ")) {
+      originalFileName = line.substring(4).trim(); // Extract original file name
+      fileName = originalFileName; // Set fileName to original initially
+      fileAction = "remove"; // Action for the original file
+    } else if (line.startsWith("+++ ")) {
+      newFileName = line.substring(4).trim(); // Extract new file name
+      fileName = newFileName; // Update fileName to new
+      fileAction = originalFileName === newFileName ? "edit" : "add"; // Determine action
+    } else if (line.startsWith("@@ ")) {
+      const parts = line.match(/@@ -(\d+),\d+ \+(\d+),\d+ @@/);
+      if (parts) {
+        line1 = parseInt(parts[1], 10); // Starting line number for the original file
+        line2 = parseInt(parts[2], 10); // Starting line number for the new file
+      }
+    } else if (line.startsWith("-")) {
+      linesRemove += line.substring(1).trim() + "\n"; // Lines removed
+    } else if (line.startsWith("+")) {
+      linesAdd += line.substring(1).trim() + "\n"; // Lines added
+    }
+  });
+
+  // If the original and new file names are different, it could be a rename
+  if (originalFileName && newFileName && originalFileName !== newFileName) {
+    fileAction = "rename";
+  }
+
+  return {
+    file_name: fileName,
+    file_action: fileAction,
+    line1: line1,
+    line2: line2,
+    lines_remove: linesRemove.trim(),
+    lines_add: linesAdd.trim(),
+  };
+}

--- a/src/services/refact/diffs.ts
+++ b/src/services/refact/diffs.ts
@@ -5,7 +5,7 @@ import { RootState } from "../../app/store";
 
 export type DiffAppliedStateArgs = {
   chunks: DiffChunk[];
-  toolCallId: string;
+  toolCallId?: string;
 };
 
 export type DiffOperationArgs = {
@@ -59,7 +59,10 @@ export const diffApi = createApi({
         return { data: result.data as DiffAppliedStateResponse };
       },
       providesTags: (_result, _error, args) => {
-        return [{ type: "DIFF_STATE", id: args.toolCallId }];
+        if (args.toolCallId) {
+          return [{ type: "DIFF_STATE", id: args.toolCallId }];
+        }
+        return [{ type: "DIFF_STATE" }];
       },
     }),
     diffApply: builder.mutation<DiffOperationResponse, DiffOperationArgs>({


### PR DESCRIPTION
# Pull Request Title
Fix: paste patch code block
https://github.com/orgs/smallcloudai/projects/5/views/1?pane=issue&itemId=78657574

## Description
When using a prompt that makes a patch, the patch is shown to the user, but when clicking copy he patch is pasted as is into the ide.

I've decieded to use the `preview` function to open the file.


## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

use this prompt 
```
Use patch() to fix the following problem

  Expected ":"

at the lint

    def __init__(self, x, y, vx, vy)

then tell if the generated patch is good in one sentence.
```
Click the diff button.


## Checklist


- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.

## Linked Issues
https://github.com/orgs/smallcloudai/projects/5/views/1?pane=issue&itemId=78657574



## Additional Notes
We'll need to test this for file renames.
