### PR TITLE
Fix: System Prompt saves after opening a New Chat

### DIFF
--- a/src/features/Chat/Thread/reducer.ts
+++ b/src/features/Chat/Thread/reducer.ts
@@ -80,6 +80,7 @@ export const chatReducer = createReducer(initialState, (builder) => {
     }
     next.tool_use = state.tool_use;
     next.thread.model = state.thread.model;
+    next.system_prompt = state.system_prompt;
     return next;
   });
 


### PR DESCRIPTION
# Fix: System Prompt saves after opening a New Chat

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- Problem: System Prompt was not saving on opening a new chat
- Solution: Adjusted `newChatAction` listener. Now passing to the next chat instance `state.system_prompt` as well.
- [Any background context or related links?](https://github.com/orgs/smallcloudai/projects/5/views/1?filterQuery=alashc&pane=issue&itemId=80036824)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->

- Step 1: Open a New Chat
- Step 2: Select a System Prompt
- Step 3: Open a New Chat and see the same System Prompt selected

## Screenshots (if applicable)

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.