### PR TITLE
Fix: Showing chat mode & Saving tool_use in a chat thread store

### DIFF
--- a/src/__fixtures__/chat.ts
+++ b/src/__fixtures__/chat.ts
@@ -65,6 +65,7 @@ export const MARS_ROVER_CHAT: ChatHistoryItem = {
   ],
   title: "mars rover kata",
   model: "gpt-3.5-turbo",
+  tool_use: "explore",
   createdAt: "2023-12-21T17:32:50.186Z",
   updatedAt: "2023-12-21T17:33:22.209Z",
 };
@@ -239,6 +240,7 @@ export const CHAT_FUNCTIONS_MESSAGES: ChatMessages = [
 
 export const FROG_CHAT: ChatThread = {
   id: "77b6a451-5598-44c0-bd5b-cfc19e3f4e60",
+  tool_use: "explore",
   messages: [
     {
       role: "context_memory",
@@ -593,6 +595,7 @@ export const CHAT_WITH_DIFF_ACTIONS: ChatThread = {
   ],
   title: "In the project add an edible property to the frog class\n",
   model: "gpt-4o",
+  tool_use: "explore",
   createdAt: "2024-07-05T09:10:29.523Z",
   updatedAt: "2024-07-05T09:10:37.322Z",
 };
@@ -817,6 +820,7 @@ export const LARGE_DIFF: ChatThread = {
   ],
   title: "rename the frog class to bird.\n",
   model: "gpt-4o",
+  tool_use: "explore",
   createdAt: "2024-07-23T15:08:51.480Z",
   updatedAt: "2024-07-23T15:36:26.738Z",
 };

--- a/src/__fixtures__/history.ts
+++ b/src/__fixtures__/history.ts
@@ -29,6 +29,7 @@ export const HISTORY: ChatHistoryItem[] = [
     model: "",
     createdAt: "2024-07-02T10:43:13.401Z",
     updatedAt: "2024-07-02T10:44:38.325Z",
+    tool_use: "explore",
   },
   {
     id: "31f3bb3d-df6e-4f0f-b701-6b1e6e4a352b",
@@ -114,5 +115,6 @@ export const HISTORY: ChatHistoryItem[] = [
     model: "",
     createdAt: "2024-07-02T10:40:27.354Z",
     updatedAt: "2024-07-02T10:40:32.341Z",
+    tool_use: "explore",
   },
 ];

--- a/src/__tests__/DeleteChat.test.tsx
+++ b/src/__tests__/DeleteChat.test.tsx
@@ -14,6 +14,7 @@ describe("Delete a Chat form history", () => {
         messages: [],
         id: "abc123",
         model: "foo",
+        tool_use: "quick",
         createdAt: now,
         updatedAt: now,
         read: true,

--- a/src/__tests__/RestoreChat.test.tsx
+++ b/src/__tests__/RestoreChat.test.tsx
@@ -34,6 +34,7 @@ describe("Restore Chat from history", () => {
             createdAt: "0",
             updatedAt: "0",
             model: "test",
+            tool_use: "explore",
             messages: [
               { role: "user", content: "test user message" },
               { role: "assistant", content: "👋" },

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -20,6 +20,7 @@ import {
   selectPreventSend,
   selectChatId,
   selectMessages,
+  getSelectedToolUse,
 } from "../../features/Chat/Thread";
 import { selectActiveFile } from "../../features/Chat/activeFile";
 import { Toolbar } from "../Toolbar";
@@ -57,6 +58,7 @@ export const Chat: React.FC<ChatProps> = ({
   const chatId = useAppSelector(selectChatId);
   const { submit, abort, retry } = useSendChatRequest();
   const chatModel = useAppSelector(getSelectedChatModel);
+  const chatToolUse = useAppSelector(getSelectedToolUse);
   const dispatch = useAppDispatch();
   const messages = useAppSelector(selectMessages);
   const onSetChatModel = useCallback(
@@ -156,7 +158,10 @@ export const Chat: React.FC<ChatProps> = ({
       />
       <Flex justify="between" pl="1" pr="1" pt="1">
         {messages.length > 0 && (
-          <Text size="1">model: {chatModel || caps.default_cap} </Text>
+          <Flex align="center" gap="1">
+            <Text size="1">model: {chatModel || caps.default_cap} </Text> •{" "}
+            <Text size="1">mode: {chatToolUse} </Text>
+          </Flex>
         )}
       </Flex>
     </PageWrapper>

--- a/src/features/Chat/Thread/actions.ts
+++ b/src/features/Chat/Thread/actions.ts
@@ -66,8 +66,6 @@ export const setPreventSend = createAction<PayloadWithId>(
 );
 
 export const setToolUse = createAction<ToolUse>("chatThread/setToolUse");
-export const getSelectedToolUse = (state: RootState) =>
-  state.chat.thread.tool_use;
 
 export const saveTitle = createAction<PayloadWithIdAndTitle>(
   "chatThread/saveTitle",

--- a/src/features/Chat/Thread/actions.ts
+++ b/src/features/Chat/Thread/actions.ts
@@ -58,6 +58,7 @@ export const setPreventSend = createAction<PayloadWithId>(
 );
 
 export const setToolUse = createAction<ToolUse>("chatThread/setToolUse");
+export const getSelectedToolUse = (state: RootState) => state.chat.tool_use;
 
 // TODO: This is the circular dep when imported from hooks :/
 const createAppAsyncThunk = createAsyncThunk.withTypes<{

--- a/src/features/Chat/Thread/actions.ts
+++ b/src/features/Chat/Thread/actions.ts
@@ -58,7 +58,8 @@ export const setPreventSend = createAction<PayloadWithId>(
 );
 
 export const setToolUse = createAction<ToolUse>("chatThread/setToolUse");
-export const getSelectedToolUse = (state: RootState) => state.chat.tool_use;
+export const getSelectedToolUse = (state: RootState) =>
+  state.chat.thread.tool_use;
 
 // TODO: This is the circular dep when imported from hooks :/
 const createAppAsyncThunk = createAsyncThunk.withTypes<{

--- a/src/features/Chat/Thread/reducer.ts
+++ b/src/features/Chat/Thread/reducer.ts
@@ -1,5 +1,5 @@
 import { createReducer } from "@reduxjs/toolkit";
-import { Chat, ChatThread } from "./types";
+import { Chat, ChatThread, ToolUse } from "./types";
 import { v4 as uuidv4 } from "uuid";
 import { chatResponse, chatAskedQuestion } from ".";
 import {
@@ -24,6 +24,7 @@ const createChatThread = (): ChatThread => {
     messages: [],
     title: "",
     model: "",
+    tool_use: "" as ToolUse,
   };
   return chat;
 };
@@ -46,6 +47,7 @@ const initialState = createInitialState();
 
 export const chatReducer = createReducer(initialState, (builder) => {
   builder.addCase(setToolUse, (state, action) => {
+    state.thread.tool_use = action.payload;
     state.tool_use = action.payload;
   });
 

--- a/src/features/Chat/Thread/selectors.ts
+++ b/src/features/Chat/Thread/selectors.ts
@@ -15,3 +15,6 @@ export const selectSendImmediately = (state: RootState) =>
   state.chat.send_immediately;
 export const getSelectedSystemPrompt = (state: RootState) =>
   state.chat.system_prompt;
+
+export const getSelectedToolUse = (state: RootState) =>
+  state.chat.thread.tool_use;

--- a/src/features/Chat/Thread/types.ts
+++ b/src/features/Chat/Thread/types.ts
@@ -9,6 +9,7 @@ export type ChatThread = {
   title?: string;
   createdAt?: string;
   updatedAt?: string;
+  tool_use: ToolUse;
   read?: boolean;
 };
 
@@ -40,4 +41,10 @@ export function checkForDetailMessage(str: string): DetailMessage | false {
   const json = parseOrElse(str, {});
   if (isDetailMessage(json)) return json;
   return false;
+}
+
+export function isToolUse(str: string): str is ToolUse {
+  if (!str) return false;
+  if (typeof str !== "string") return false;
+  return str === "quick" || str === "explore" || str === "agent";
 }

--- a/src/hooks/useSendChatRequest.ts
+++ b/src/hooks/useSendChatRequest.ts
@@ -22,7 +22,9 @@ import {
   backUpMessages,
   chatAskQuestionThunk,
   chatAskedQuestion,
+  setToolUse,
 } from "../features/Chat/Thread/actions";
+import { isToolUse } from "../features/Chat";
 
 export const useSendChatRequest = () => {
   const dispatch = useAppDispatch();
@@ -59,6 +61,9 @@ export const useSendChatRequest = () => {
   const sendMessages = useCallback(
     (messages: ChatMessages) => {
       let tools = toolsRequest.data ?? null;
+      if (isToolUse(toolUse)) {
+        dispatch(setToolUse(toolUse));
+      }
       if (toolUse === "quick") {
         tools = [];
       } else if (toolUse === "explore") {


### PR DESCRIPTION
# Fix: Showing chat mode & Saving tool_use in a chat thread store

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- Problem: User had no way to get information in existing chat window what agentic capabilities mode it is using. Actual mode of a chat was not stored properly in history and within a chat. All chat threads were working based on a agentic capabilities selected for whole application.
- Solution: Adjusted Application's UI a bit to show up a mode, also added a new selector to get `tool_use` of a current thread. Created a field of `tool_use` within thread as well, so it could rely on its own `tool_use` and not a global one (global one is needed to remember which mode user has selected previously, but in terms of lots of chats - proper way is to save thread's `tool_use` as well)
- [First issue](https://github.com/orgs/smallcloudai/projects/5/views/1?pane=issue&itemId=80350424)
- [Second issue](https://github.com/orgs/smallcloudai/projects/5/views/1?pane=issue&itemId=80474100)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

- Step 1: Open a new chat, choose a mode, ask for something
- Step 2: Exit chat, create a new one and change a mode one more time, ask for something as well (remember which mode you have specified)
- Step 3: Exit to a home screen, select an older chat from a history and check for mode to be reliable
- Step 4: Exit to a home screen, select a newer chat from a history and check for mode to be reliable as well
- Step 5: Create a new chat and check if selected mode corresponds to which you have remembered in the second step.

## Screenshots (if applicable)

<!-- If your changes include UI modifications, attach relevant screenshots here. -->
### Mode visualization
![Mode visualization](https://github.com/user-attachments/assets/9085635a-f16d-46ba-b96b-e4531fb408d9)

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.