### PR TITLE
Fix: Auto Select Checkboxes on New Chat

### DIFF
--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -122,6 +122,7 @@ export const Chat: React.FC<ChatProps> = ({
       )}
 
       <ChatForm
+        key={chatId} // TODO: think of how can we not trigger re-render on chatId change (checkboxes)
         chatId={chatId}
         isStreaming={isStreaming}
         showControls={messages.length === 0 && !isStreaming}


### PR DESCRIPTION
# Fix: Auto Select Checkboxes on New Chat

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- Problem: After first user's interaction, checkboxes were not auto-selecting even in a new chat
- Solution: Provide a key prop for `ChatForm` component so it re-renders and re-renders checkboxes within it on a `chatId` change of a chat thread
- [Any background context or related links?](https://github.com/orgs/smallcloudai/projects/5/?pane=issue&itemId=80461847)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->

- Step 1: Open a chat window, try to select some lines and interact with checkboxes
- Step 2: Click "New Chat" in a toolbar
- Step 3: Check if checkboxes are getting auto-selected if you don't interact with them, but selecting lines

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.