### PR TITLE
fix(stop chat after cache restore, and ensure tool_use is defined)

### DIFF
--- a/src/contexts/AbortControllers.tsx
+++ b/src/contexts/AbortControllers.tsx
@@ -1,0 +1,50 @@
+import React, { createContext, useState } from "react";
+
+type AboutFunction = (reason?: string) => void;
+
+type AbortControllerContext = {
+  addAbortController: (key: string, fn: AboutFunction) => void;
+  abort: (key: string, reason?: string) => void;
+  removeController: (key: string) => void;
+};
+
+export const AbortControllerContext =
+  createContext<null | AbortControllerContext>(null);
+
+export const AbortControllerProvider: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  const [abortControllers, setAbortControllers] = useState<
+    Record<string, (reason?: string) => void>
+  >({});
+
+  const addAbortController: AbortControllerContext["addAbortController"] = (
+    key,
+    fn,
+  ) => {
+    setAbortControllers((prev) => ({ ...prev, [key]: fn }));
+  };
+
+  const removeController = (key: string) =>
+    setAbortControllers((prev) => {
+      return Object.entries(prev)
+        .filter(([k]) => k !== key)
+        .reduce((acc, [k, v]) => ({ ...acc, [k]: v }), {});
+    });
+
+  const abort = (key: string, reason?: string) => {
+    if (key in abortControllers) {
+      const fn = abortControllers[key];
+      fn(reason);
+      removeController(key);
+    }
+  };
+
+  return (
+    <AbortControllerContext.Provider
+      value={{ addAbortController, removeController, abort }}
+    >
+      {children}
+    </AbortControllerContext.Provider>
+  );
+};

--- a/src/features/App.tsx
+++ b/src/features/App.tsx
@@ -28,6 +28,7 @@ import { Tour } from "../components/Tour";
 import { TourEnd } from "../components/Tour/TourEnd";
 import { useEventBusForApp } from "../hooks/useEventBusForApp";
 import { BringYourOwnKey } from "../components/BringYourOwnKey/BringYourOwnKey";
+import { AbortControllerProvider } from "../contexts/AbortControllers";
 
 export interface AppProps {
   style?: React.CSSProperties;
@@ -190,7 +191,9 @@ export const App = () => {
       <PersistGate persistor={persistor}>
         <Theme>
           <TourProvider>
-            <InnerApp />
+            <AbortControllerProvider>
+              <InnerApp />
+            </AbortControllerProvider>
           </TourProvider>
         </Theme>
       </PersistGate>

--- a/src/features/Chat/Thread/reducer.ts
+++ b/src/features/Chat/Thread/reducer.ts
@@ -19,27 +19,27 @@ import {
 } from "./actions";
 import { formatChatResponse } from "./utils";
 
-const createChatThread = (): ChatThread => {
+const createChatThread = (tool_use: ToolUse): ChatThread => {
   const chat: ChatThread = {
     id: uuidv4(),
     messages: [],
     title: "",
     model: "",
-    tool_use: "" as ToolUse,
+    tool_use,
   };
   return chat;
 };
 
-const createInitialState = (): Chat => {
+const createInitialState = (tool_use: ToolUse = "explore"): Chat => {
   return {
     streaming: false,
-    thread: createChatThread(),
+    thread: createChatThread(tool_use),
     error: null,
     prevent_send: false,
     waiting_for_response: false,
     cache: {},
     system_prompt: {},
-    tool_use: "explore",
+    tool_use,
     send_immediately: false,
   };
 };
@@ -76,12 +76,11 @@ export const chatReducer = createReducer(initialState, (builder) => {
   });
 
   builder.addCase(newChatAction, (state) => {
-    const next = createInitialState();
+    const next = createInitialState(state.tool_use);
     next.cache = { ...state.cache };
     if (state.streaming) {
       next.cache[state.thread.id] = { ...state.thread, read: false };
     }
-    next.tool_use = state.tool_use;
     next.thread.model = state.thread.model;
     next.system_prompt = state.system_prompt;
     return next;
@@ -172,6 +171,7 @@ export const chatReducer = createReducer(initialState, (builder) => {
       state.streaming = false;
     }
     state.thread = mostUptoDateThread;
+    state.thread.tool_use = state.thread.tool_use ?? state.tool_use;
   });
 
   // New builder to save chat title within the current thread and not only inside of a history thread

--- a/src/features/Chat/Thread/types.ts
+++ b/src/features/Chat/Thread/types.ts
@@ -9,7 +9,7 @@ export type ChatThread = {
   title?: string;
   createdAt?: string;
   updatedAt?: string;
-  tool_use: ToolUse;
+  tool_use?: ToolUse;
   read?: boolean;
 };
 

--- a/src/features/Chat/Thread/utils.ts
+++ b/src/features/Chat/Thread/utils.ts
@@ -339,7 +339,6 @@ export function consumeStream(
   }: ReadableStreamReadResult<Uint8Array>): Promise<void> {
     if (done) return Promise.resolve();
     if (signal.aborted) {
-      // dispatch(setPreventSend({ id: chatId }));
       onAbort();
       return Promise.resolve();
     }

--- a/src/hooks/useAbortControllers.ts
+++ b/src/hooks/useAbortControllers.ts
@@ -1,0 +1,12 @@
+import { useContext } from "react";
+import { AbortControllerContext } from "../contexts/AbortControllers";
+
+export const useAbortControllers = () => {
+  const context = useContext(AbortControllerContext);
+  if (context === null) {
+    throw new Error(
+      "useAbortControllers must be used within a AbortControllerProvider",
+    );
+  }
+  return context;
+};

--- a/src/utils/test-utils.tsx
+++ b/src/utils/test-utils.tsx
@@ -7,6 +7,7 @@ import { Theme } from "@radix-ui/themes";
 import { Provider } from "react-redux";
 import { AppStore, RootState, setUpStore } from "../app/store";
 import { TourProvider } from "../features/Tour";
+import { AbortControllerProvider } from "../contexts/AbortControllers";
 
 // This type interface extends the default options for render from RTL, as well
 // as allows the user to specify other things such as initialState, store.
@@ -35,7 +36,9 @@ const customRender = (
   const Wrapper = ({ children }: PropsWithChildren) => (
     <Provider store={store}>
       <Theme>
-        <TourProvider>{children}</TourProvider>
+        <TourProvider>
+          <AbortControllerProvider>{children}</AbortControllerProvider>
+        </TourProvider>
       </Theme>
     </Provider>
   );


### PR DESCRIPTION

# Pull Request Title
Stop button should work after restoring from cache.


## Description

- What was the problem?
+ When the user moves from a chat while it's still streaming and opens it again the stop button no longer works.
- How did you solve it?
+ Added a hash-map for the abort functions which is hoisted into a context object at the top of the app.
- Any background context or related links?

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

1. Start a chat
2. Click home.
3. Click back on the chat.
4. Click stop, chat should stop.

Also, check that the tool_use property on the thread is retained.


## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.

## Linked Issues
https://github.com/orgs/smallcloudai/projects/5/views/1?pane=issue&itemId=81525640

## Additional Notes

<!-- Any additional information that might be useful during the review process. -->
