### PR TITLE
Fix: Conditional rendering of [➕ Diff ] button

### DIFF
--- a/src/components/ChatContent/AssistantInput.tsx
+++ b/src/components/ChatContent/AssistantInput.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { Markdown } from "../Markdown";
 
 import { Container, Box } from "@radix-ui/themes";
@@ -6,6 +6,7 @@ import { ToolCall } from "../../services/refact";
 import { ToolContent } from "./ToolsContent";
 import { useAppSelector, useEventsBusForIDE } from "../../hooks";
 import { selectActiveFile } from "../../features/Chat/activeFile";
+import { selectSelectedSnippet } from "../../features/Chat";
 
 type ChatInputProps = {
   message: string | null;
@@ -33,6 +34,14 @@ export const AssistantInput: React.FC<ChatInputProps> = ({
   toolCalls,
 }) => {
   const activeFile = useAppSelector(selectActiveFile);
+
+  const snippet = useAppSelector(selectSelectedSnippet);
+
+  const codeLineCount = useMemo(() => {
+    if (snippet.code.length === 0) return 0;
+    return snippet.code.split("\n").filter((str) => str).length;
+  }, [snippet.code]);
+
   const { newFile, diffPasteBack } = useEventsBusForIDE();
   const handleCopy = useCallback((text: string) => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -54,7 +63,7 @@ export const AssistantInput: React.FC<ChatInputProps> = ({
             onCopyClick={handleCopy}
             onNewFileClick={newFile}
             onPasteClick={diffPasteBack}
-            canPaste={activeFile.can_paste}
+            canPaste={activeFile.can_paste && codeLineCount > 0}
             canHavePins={true}
           >
             {message}


### PR DESCRIPTION
# Fix: Conditional rendering of [➕ Diff ] button

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- Problem: [➕ Diff ] button was rendered even if user didn't select any lines of code.
- Solution: Get selected snippet from the store and calculate amount of code lines within selection. If amount of lines is greater than 0, so we can render [➕ Diff ] button
- Diff workflow

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->

- Step 1: Link current branch to the `refact-vscode` repository or rather make a build for `refact-intellij` repository and launch an extension/plugin in debug mode
- Step 2: Ask chat model to generate some code chunk
- Step 3: Try to select and unselect code within the editor

Expected Result:
- If lines are selected: [➕ Diff ] button should appear near to [ New File ] and [ Copy ] buttons
- If lines are unselected: [➕ Diff ] button should disappear

## Screenshots (if applicable)
## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.