### PR TITLE
Limit history to 100 items

### DIFF
--- a/src/features/History/historySlice.ts
+++ b/src/features/History/historySlice.ts
@@ -54,6 +54,17 @@ export const historySlice = createSlice({
       };
 
       state[chat.id] = chat;
+
+      if (Object.entries(state).length >= 100) {
+        const sortedByLastUpdated = Object.values(state).sort((a, b) =>
+          b.updatedAt.localeCompare(a.updatedAt),
+        );
+        const newHistory = sortedByLastUpdated.slice(0, 100);
+        state = newHistory.reduce(
+          (acc, chat) => ({ ...acc, [chat.id]: chat }),
+          {},
+        );
+      }
     },
 
     markChatAsUnread: (state, action: PayloadAction<string>) => {


### PR DESCRIPTION
# Limits chat history to 100 items


## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test


1. Make a lot of chats, 
2. History shouldn't be more than 100
3. The chats will be removed by `updateAt` value

## Screenshots (if applicable)


## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.

## Linked Issues
https://github.com/orgs/smallcloudai/projects/5/views/1?pane=issue&itemId=79233318

## Additional Notes

<!-- Any additional information that might be useful during the review process. -->
