### PR TITLE
Fix: Cursor line showing for attached file

### DIFF
--- a/src/components/ChatForm/FilesPreview.tsx
+++ b/src/components/ChatForm/FilesPreview.tsx
@@ -11,8 +11,12 @@ export const FilesPreview: React.FC<{
   return (
     <Box p="2" pb="0">
       {files.map((file, i) => {
-        const lineText =
-          file.line1 && file.line2 ? `:${file.line1}-${file.line2}` : "";
+        const lineText = file.cursor
+          ? `:${file.line1}-${file.cursor}`
+          : file.line1 && file.line2
+            ? `:${file.line1}-${file.line2}`
+            : "";
+
         return (
           <pre key={file.file_name + i} className={styles.file}>
             <Text

--- a/src/components/ChatForm/useCommandCompletionAndPreviewFiles.ts
+++ b/src/components/ChatForm/useCommandCompletionAndPreviewFiles.ts
@@ -9,6 +9,7 @@ import {
   commandsApi,
 } from "../../services/refact/commands";
 import { ChatContextFile } from "../../services/refact/types";
+import { selectActiveFile } from "../../features/Chat";
 
 function useGetCommandCompletionQuery(
   query: string,
@@ -100,12 +101,25 @@ function useGetPreviewFiles(query: string, checkboxes: Checkboxes) {
 
 export function useCommandCompletionAndPreviewFiles(checkboxes: Checkboxes) {
   const { commands, requestCompletion, query } = useCommandCompletion();
-
+  const activeFile = useAppSelector(selectActiveFile);
   const previewFileResponse = useGetPreviewFiles(query, checkboxes);
+
+  const previewFiles = previewFileResponse.map((file) => {
+    if (activeFile.path.includes(file.file_name)) {
+      return {
+        ...file,
+        cursor: activeFile.cursor ?? undefined,
+      };
+    }
+
+    return {
+      ...file,
+    };
+  });
 
   return {
     commands,
     requestCompletion,
-    previewFiles: previewFileResponse,
+    previewFiles,
   };
 }

--- a/src/services/refact/types.ts
+++ b/src/services/refact/types.ts
@@ -16,6 +16,7 @@ export type ChatContextFile = {
   file_content: string;
   line1: number;
   line2: number;
+  cursor?: number;
   usefulness?: number;
   usefullness?: number;
 };


### PR DESCRIPTION
# Fix: Cursor line showing for attached file

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- Problem: Attached file was previewed with `:%START_LINE%-%END_LINE%` and not with `:%START_LINE%-%CURSOR_LINE%`
- Solution: Adding additional check to synchronize response from LSP for `v1/command-preview` and actual active file within the IDE
- [Any background context or related links?](https://github.com/orgs/smallcloudai/projects/5/views/1?pane=issue&itemId=81524949)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->

- Step 1: Start a new chat in IDE
- Step 2: Open any file inside the editor
- Step 3: Attach this file via checkbox
- Step 4: Move the cursor within editor's window and see how attachment changes

## Screenshots (if applicable)

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.