### PR TITLE
Fix: Lines selection checkbox behavior

### DIFF
--- a/src/components/ChatForm/ChatForm.tsx
+++ b/src/components/ChatForm/ChatForm.tsx
@@ -64,8 +64,13 @@ export const ChatForm: React.FC<ChatFormProps> = ({
   const onClearError = useCallback(() => dispatch(clearError()), [dispatch]);
   const [value, setValue] = React.useState("");
 
-  const { checkboxes, onToggleCheckbox, setInteracted, unCheckAll } =
-    useCheckboxes();
+  const {
+    checkboxes,
+    onToggleCheckbox,
+    setFileInteracted,
+    setLineSelectionInteracted,
+    unCheckAll,
+  } = useCheckboxes();
 
   const { previewFiles, commands, requestCompletion } =
     useCommandCompletionAndPreviewFiles(checkboxes);
@@ -130,7 +135,8 @@ export const ChatForm: React.FC<ChatFormProps> = ({
   const handleChange = useCallback(
     (command: string) => {
       setValue(command);
-      setInteracted(true);
+      setFileInteracted(true);
+      setLineSelectionInteracted(true);
       const trimmedCommand = command.trim();
       if (trimmedCommand === "@help") {
         handleHelpInfo(helpText()); // This line has been fixed
@@ -138,7 +144,7 @@ export const ChatForm: React.FC<ChatFormProps> = ({
         handleHelpInfo(null);
       }
     },
-    [setInteracted, handleHelpInfo],
+    [setFileInteracted, setLineSelectionInteracted, handleHelpInfo],
   );
 
   if (error) {

--- a/src/components/ChatForm/ChatForm.tsx
+++ b/src/components/ChatForm/ChatForm.tsx
@@ -64,13 +64,7 @@ export const ChatForm: React.FC<ChatFormProps> = ({
   const onClearError = useCallback(() => dispatch(clearError()), [dispatch]);
   const [value, setValue] = React.useState("");
 
-  const {
-    checkboxes,
-    onToggleCheckbox,
-    setFileInteracted,
-    setLineSelectionInteracted,
-    unCheckAll,
-  } = useCheckboxes();
+  const { checkboxes, onToggleCheckbox, unCheckAll } = useCheckboxes();
 
   const { previewFiles, commands, requestCompletion } =
     useCommandCompletionAndPreviewFiles(checkboxes);
@@ -135,8 +129,6 @@ export const ChatForm: React.FC<ChatFormProps> = ({
   const handleChange = useCallback(
     (command: string) => {
       setValue(command);
-      setFileInteracted(true);
-      setLineSelectionInteracted(true);
       const trimmedCommand = command.trim();
       if (trimmedCommand === "@help") {
         handleHelpInfo(helpText()); // This line has been fixed
@@ -144,7 +136,7 @@ export const ChatForm: React.FC<ChatFormProps> = ({
         handleHelpInfo(null);
       }
     },
-    [setFileInteracted, setLineSelectionInteracted, handleHelpInfo],
+    [handleHelpInfo],
   );
 
   if (error) {

--- a/src/components/ChatForm/useCheckBoxes.ts
+++ b/src/components/ChatForm/useCheckBoxes.ts
@@ -128,18 +128,16 @@ const useAttachSelectedSnippet = (
     });
 
   useEffect(() => {
-    if (!attachedSelectedSnippet.checked || !interacted) {
-      setAttachedSelectedSnippet((prev) => {
-        return {
-          ...prev,
-          label: label,
-          value: markdown,
-          disabled: !snippet.code,
-          hide: host === "web",
-          checked: !!snippet.code && !interacted,
-        };
-      });
-    }
+    setAttachedSelectedSnippet((prev) => {
+      return {
+        ...prev,
+        label: label,
+        value: markdown,
+        disabled: !snippet.code,
+        hide: host === "web",
+        checked: !!snippet.code && !interacted,
+      };
+    });
   }, [
     snippet.code,
     host,
@@ -218,14 +216,15 @@ export type Checkboxes = {
 };
 
 export const useCheckboxes = () => {
-  const [interacted, setInteracted] = useState(false);
+  const [lineSelectionInteracted, setLineSelectionInteracted] = useState(false);
+  const [fileInteracted, setFileInteracted] = useState(false);
 
   const [attachedSelectedSnippet, onToggleAttachedSelectedSnippet] =
-    useAttachSelectedSnippet(interacted);
+    useAttachSelectedSnippet(lineSelectionInteracted);
   const [searchWorkspace, onToggleSearchWorkspace] = useSearchWorkSpace();
 
   const [attachFileCheckboxData, onToggleAttachFile] = useAttachActiveFile(
-    interacted,
+    fileInteracted,
     attachedSelectedSnippet.checked,
   );
 
@@ -246,13 +245,14 @@ export const useCheckboxes = () => {
           break;
         case "file_upload":
           onToggleAttachFile();
+          setFileInteracted(true);
           break;
         case "selected_lines":
           onToggleAttachedSelectedSnippet();
+          setFileInteracted(true);
+          setLineSelectionInteracted(true);
           break;
       }
-
-      setInteracted(true);
     },
     [
       onToggleAttachFile,
@@ -280,5 +280,11 @@ export const useCheckboxes = () => {
     searchWorkspace.checked,
   ]);
 
-  return { checkboxes, onToggleCheckbox, setInteracted, unCheckAll };
+  return {
+    checkboxes,
+    onToggleCheckbox,
+    setFileInteracted,
+    setLineSelectionInteracted,
+    unCheckAll,
+  };
 };

--- a/src/components/ChatForm/useCheckBoxes.ts
+++ b/src/components/ChatForm/useCheckBoxes.ts
@@ -138,14 +138,7 @@ const useAttachSelectedSnippet = (
         checked: !!snippet.code && !interacted,
       };
     });
-  }, [
-    snippet.code,
-    host,
-    attachedSelectedSnippet.checked,
-    label,
-    markdown,
-    interacted,
-  ]);
+  }, [snippet.code, host, label, markdown, interacted]);
 
   const onToggleAttachedSelectedSnippet = useCallback(() => {
     setAttachedSelectedSnippet((prev) => {
@@ -250,7 +243,7 @@ export const useCheckboxes = () => {
         case "selected_lines":
           onToggleAttachedSelectedSnippet();
           setFileInteracted(true);
-          setLineSelectionInteracted(true);
+          setLineSelectionInteracted((prev) => !prev);
           break;
       }
     },

--- a/src/components/ChatForm/useCheckBoxes.ts
+++ b/src/components/ChatForm/useCheckBoxes.ts
@@ -128,6 +128,8 @@ const useAttachSelectedSnippet = (
     });
 
   useEffect(() => {
+    // removing unnecessary check for checked state and interacted state
+    // and excluding attachedSelectedSnippet.checked from dependency array
     setAttachedSelectedSnippet((prev) => {
       return {
         ...prev,
@@ -209,6 +211,7 @@ export type Checkboxes = {
 };
 
 export const useCheckboxes = () => {
+  // creating 2 different states instead of only one being used for both checkboxes
   const [lineSelectionInteracted, setLineSelectionInteracted] = useState(false);
   const [fileInteracted, setFileInteracted] = useState(false);
 


### PR DESCRIPTION
# Fix: Lines selection checkbox behavior

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- Problem: After very first user interaction on checkbox, it was behaving not as expected, especially, after trying to select lines after explicitly checking up the checkbox - it was not counting lines correctly.
- Solution: Implemented 2 different interacted states for both file attachment and lines selection checkboxes, adjustment of `useAttachSelectedSnippet` logic within `useEffect`.
- [Any background context or related links?](https://github.com/orgs/smallcloudai/projects/5/views/1?filterQuery=alashchev17&pane=issue&itemId=78566457)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->

- Step 1: Start a new chat, then select some code
- Step 2: Uncheck lines selection checkbox, remove lines selection
- Step 3: Try to select lines in editor's tab again
- Step 4: Check the lines selection checkbox, then click on the editor's tab (to not loose the current lines selection), then press arrow keys on your keyboard with held `Shift` key to change lines selection without resetting a current lines selection

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.

## Additional Notes

<!-- Any additional information that might be useful during the review process. -->

Stays in draft pull requests until tests are getting fixed