### PR TITLE
Show patch ticket from ide

### DIFF
--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -13,8 +13,8 @@ import type { TipOfTheDayState } from "../features/TipOfTheDay";
 import type { PageSliceState } from "../features/Pages/pagesSlice";
 import type { TourState } from "../features/Tour";
 import type { FIMDebugState } from "../hooks";
+import { createAction } from "@reduxjs/toolkit";
 
-// import { rootReducer } from "../app/store";
 export { updateConfig, type Config } from "../features/Config/configSlice";
 export { type FileInfo, setFileInfo } from "../features/Chat/activeFile";
 export {
@@ -24,6 +24,9 @@ export {
 export type { FimDebugData } from "../services/refact/fim";
 export type { ChatHistoryItem } from "../features/History/historySlice";
 export { resetDiffApi } from "../services/refact/diffs";
+
+export const showPatchTicket = createAction<string>("showPatchTicket");
+
 // TODO: re-exporting from redux seems to break things :/
 export type InitialState = {
   fim: FIMDebugState;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -20,3 +20,4 @@ export * from "./useConfig";
 export * from "./useAppDispatch";
 export * from "./useAppSelector";
 export * from "./useSendChatRequest";
+export * from "./usePatchActions";

--- a/src/hooks/useEventBusForApp.ts
+++ b/src/hooks/useEventBusForApp.ts
@@ -12,11 +12,14 @@ import {
   selectPages,
 } from "../features/Pages/pagesSlice";
 import { diffApi, resetDiffApi } from "../services/refact/diffs";
+import { usePatchActions } from "./usePatchActions";
+import { showPatchTicket } from "../events";
 
 export function useEventBusForApp() {
   const config = useConfig();
   const dispatch = useAppDispatch();
   const pages = useAppSelector(selectPages);
+  const { handleShow } = usePatchActions();
 
   useEffect(() => {
     const listener = (event: MessageEvent) => {
@@ -42,6 +45,10 @@ export function useEventBusForApp() {
       if (resetDiffApi.match(event.data)) {
         dispatch(diffApi.util.resetApiState());
       }
+
+      if (showPatchTicket.match(event.data)) {
+        handleShow(event.data.payload);
+      }
     };
 
     window.addEventListener("message", listener);
@@ -49,5 +56,5 @@ export function useEventBusForApp() {
     return () => {
       window.removeEventListener("message", listener);
     };
-  }, [config.host, dispatch, pages]);
+  }, [config.host, dispatch, handleShow, pages]);
 }

--- a/src/hooks/useEventBusForIDE.ts
+++ b/src/hooks/useEventBusForIDE.ts
@@ -11,8 +11,9 @@ import type { DiffPreviewResponse, PatchResult } from "../services/refact";
 
 export const ideDiffPasteBackAction = createAction<string>("ide/diffPasteBack");
 
-export const ideDiffPreviewAction =
-  createAction<DiffPreviewResponse>("ide/diffPreview");
+export const ideDiffPreviewAction = createAction<
+  DiffPreviewResponse & { currentPin: string; allPins: string[] }
+>("ide/diffPreview");
 
 export const ideOpenSettingsAction = createAction("ide/openSettings");
 
@@ -85,8 +86,8 @@ export const useEventsBusForIDE = () => {
   );
 
   const diffPreview = useCallback(
-    (preview: DiffPreviewResponse) => {
-      postMessage(ideDiffPreviewAction(preview));
+    (preview: DiffPreviewResponse, currentPin: string, allPins: string[]) => {
+      postMessage(ideDiffPreviewAction({ ...preview, currentPin, allPins }));
     },
     [postMessage],
   );

--- a/src/hooks/usePatchActions.ts
+++ b/src/hooks/usePatchActions.ts
@@ -1,0 +1,149 @@
+import { useState, useCallback, useMemo } from "react";
+import { useSelector } from "react-redux";
+import {
+  AssistantMessage,
+  diffApi,
+  isAssistantMessage,
+  isDetailMessage,
+} from "../services/refact";
+import {
+  selectMessages,
+  selectIsStreaming,
+  selectIsWaiting,
+} from "../features/Chat";
+import { useEventsBusForIDE } from "./useEventBusForIDE";
+
+export const usePatchActions = () => {
+  const {
+    diffPreview,
+    startFileAnimation,
+    stopFileAnimation,
+    openFile,
+    writeResultsToFile,
+  } = useEventsBusForIDE();
+  const messages = useSelector(selectMessages);
+  const isStreaming = useSelector(selectIsStreaming);
+  const isWaiting = useSelector(selectIsWaiting);
+
+  const [errorMessage, setErrorMessage] = useState<{
+    type: "warning" | "error";
+    text: string;
+  } | null>(null);
+
+  const resetErrorMessage = useCallback(() => {
+    setErrorMessage(null);
+  }, []);
+
+  const [getPatch, patchResult] =
+    diffApi.usePatchSingleFileFromTicketMutation();
+
+  const disable = useMemo(() => {
+    return !!errorMessage || isStreaming || isWaiting || patchResult.isLoading;
+  }, [errorMessage, isStreaming, isWaiting, patchResult.isLoading]);
+
+  const pinMessages = useMemo(() => {
+    const assistantMessages: AssistantMessage[] =
+      messages.filter(isAssistantMessage);
+
+    const lines = assistantMessages.reduce<string[]>((acc, curr) => {
+      if (!curr.content) return acc;
+      return acc.concat(curr.content.split("\n"));
+    }, []);
+
+    return lines.filter((line) => line.startsWith("📍"));
+  }, [messages]);
+
+  const handleShow = useCallback(
+    (pin: string) => {
+      const [, , fileName] = pin.split(" ");
+      startFileAnimation(fileName);
+      getPatch({ pin, messages })
+        .unwrap()
+        .then((maybeDetail) => {
+          if (isDetailMessage(maybeDetail)) {
+            const error = new Error(maybeDetail.detail);
+            throw error;
+          }
+          return maybeDetail;
+        })
+        .then((patch) => {
+          stopFileAnimation(fileName);
+          diffPreview(patch, pin, pinMessages);
+        })
+        .catch((error: Error | { data: { detail: string } }) => {
+          stopFileAnimation(fileName);
+          if ("message" in error) {
+            setErrorMessage({
+              type: "error",
+              text: "Failed to open patch: " + error.message,
+            });
+          } else {
+            setErrorMessage({
+              type: "error",
+              text: "Failed to open patch: " + error.data.detail,
+            });
+          }
+        });
+    },
+    [
+      diffPreview,
+      getPatch,
+      messages,
+      pinMessages,
+      startFileAnimation,
+      stopFileAnimation,
+    ],
+  );
+
+  const handleApply = useCallback(
+    (pin: string) => {
+      const [, , fileName] = pin.split(" ");
+      startFileAnimation(fileName);
+
+      getPatch({ pin, messages })
+        .unwrap()
+        .then((maybeDetail) => {
+          if (isDetailMessage(maybeDetail)) {
+            const error = new Error(maybeDetail.detail);
+            throw error;
+          }
+          return maybeDetail;
+        })
+        .then((patch) => {
+          stopFileAnimation(fileName);
+          writeResultsToFile(patch.results);
+        })
+        .catch((error: Error | { data: { detail: string } }) => {
+          stopFileAnimation(fileName);
+          if ("message" in error) {
+            setErrorMessage({
+              type: "error",
+              text: "Failed to apply patch: " + error.message,
+            });
+          } else {
+            setErrorMessage({
+              type: "error",
+              text: "Failed to apply patch: " + error.data.detail,
+            });
+          }
+        });
+    },
+    [
+      getPatch,
+      messages,
+      startFileAnimation,
+      stopFileAnimation,
+      writeResultsToFile,
+    ],
+  );
+
+  return {
+    errorMessage,
+    handleShow,
+    patchResult,
+    handleApply,
+    resetErrorMessage,
+    disable,
+    openFile,
+  };
+};


### PR DESCRIPTION
# Show next patch ticket from ide

## Description

Adds an event that allows the ide to send the next pin message to be run.

## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

1. Use this branch for vscode https://github.com/smallcloudai/refact-vscode/pull/149
2. Build and link chat.
3. Ask `rename Frog to bird with out changing any files`
4. Click `accept and continue` to go to the next patch

## Screenshots (if applicable)



## Checklist


- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.

## Linked Issues


## Additional Notes

The codeLens looks a bit long.
The patch can be slow to open a file :/
