### PR TITLE
Fix: Files Preview

### DIFF
--- a/src/components/ChatForm/FilesPreview.tsx
+++ b/src/components/ChatForm/FilesPreview.tsx
@@ -11,11 +11,7 @@ export const FilesPreview: React.FC<{
   return (
     <Box p="2" pb="0">
       {files.map((file, i) => {
-        const lineText = file.cursor
-          ? `:${file.line1}-${file.cursor}`
-          : file.line1 && file.line2
-            ? `:${file.line1}-${file.line2}`
-            : "";
+        const lineText = `:${file.line1}-${file.line2}`;
 
         return (
           <pre key={file.file_name + i} className={styles.file}>

--- a/src/components/ChatForm/useCheckBoxes.ts
+++ b/src/components/ChatForm/useCheckBoxes.ts
@@ -35,8 +35,10 @@ const useAttachActiveFile = (
     const hasLines = activeFile.line1 !== null && activeFile.line2 !== null;
 
     if (!hasLines) return activeFile.path;
-    return `${activeFile.path}:${activeFile.line1}-${activeFile.line2}`;
-  }, [activeFile.path, activeFile.line1, activeFile.line2]);
+    return `${activeFile.path}:${
+      activeFile.cursor ? activeFile.cursor + 1 : activeFile.line1
+    }`;
+  }, [activeFile.path, activeFile.cursor, activeFile.line1, activeFile.line2]);
 
   const [attachFileCheckboxData, setAttachFile] = useState<Checkbox>({
     name: "file_upload",
@@ -54,26 +56,17 @@ const useAttachActiveFile = (
   });
 
   useEffect(() => {
-    if (!attachFileCheckboxData.checked || !interacted) {
-      setAttachFile((prev) => {
-        return {
-          ...prev,
-          hide: !shouldShow,
-          value: filePathWithLines,
-          disabled: !activeFile.name,
-          fileName: activeFile.name,
-          checked: !!activeFile.name && shouldShow && hasSnippet && !interacted,
-        };
-      });
-    }
-  }, [
-    activeFile.name,
-    attachFileCheckboxData.checked,
-    filePathWithLines,
-    hasSnippet,
-    interacted,
-    shouldShow,
-  ]);
+    setAttachFile((prev) => {
+      return {
+        ...prev,
+        hide: !shouldShow,
+        value: filePathWithLines,
+        disabled: !activeFile.name,
+        fileName: activeFile.name,
+        checked: interacted ? prev.checked : !!activeFile.name && shouldShow,
+      };
+    });
+  }, [activeFile.name, filePathWithLines, hasSnippet, interacted, shouldShow]);
 
   useEffect(() => {
     if (messageLength > 0 && attachFileCheckboxData.hide === false) {

--- a/src/components/ChatForm/useCommandCompletionAndPreviewFiles.ts
+++ b/src/components/ChatForm/useCommandCompletionAndPreviewFiles.ts
@@ -9,7 +9,6 @@ import {
   commandsApi,
 } from "../../services/refact/commands";
 import { ChatContextFile } from "../../services/refact/types";
-import { selectActiveFile } from "../../features/Chat";
 
 function useGetCommandCompletionQuery(
   query: string,
@@ -79,7 +78,8 @@ function useGetPreviewFiles(query: string, checkboxes: Checkboxes) {
 
   const queryWithCheckboxes = useMemo(
     () => addCheckboxValuesToInput(query, checkboxes, hasVecdb),
-    [checkboxes, query, hasVecdb],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [checkboxes, query, hasVecdb, checkboxes.file_upload.value],
   );
   const [previewQuery, setPreviewQuery] = useState<string>(queryWithCheckboxes);
 
@@ -93,7 +93,11 @@ function useGetPreviewFiles(query: string, checkboxes: Checkboxes) {
 
   useEffect(() => {
     debounceSetPreviewQuery(queryWithCheckboxes);
-  }, [debounceSetPreviewQuery, queryWithCheckboxes]);
+  }, [
+    debounceSetPreviewQuery,
+    queryWithCheckboxes,
+    checkboxes.file_upload.value,
+  ]);
 
   const previewFileResponse = useGetCommandPreviewQuery(previewQuery);
   return previewFileResponse;
@@ -101,25 +105,11 @@ function useGetPreviewFiles(query: string, checkboxes: Checkboxes) {
 
 export function useCommandCompletionAndPreviewFiles(checkboxes: Checkboxes) {
   const { commands, requestCompletion, query } = useCommandCompletion();
-  const activeFile = useAppSelector(selectActiveFile);
   const previewFileResponse = useGetPreviewFiles(query, checkboxes);
-
-  const previewFiles = previewFileResponse.map((file) => {
-    if (activeFile.path.includes(file.file_name)) {
-      return {
-        ...file,
-        cursor: activeFile.cursor ?? undefined,
-      };
-    }
-
-    return {
-      ...file,
-    };
-  });
 
   return {
     commands,
     requestCompletion,
-    previewFiles,
+    previewFiles: previewFileResponse,
   };
 }


### PR DESCRIPTION
# Fix: Files Preview

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- Problem: Files Preview was re-rendering depending on cursor line, command preview query was not containing current cursor line
- Solution: Adjusted `useCheckboxes` hook conditions for changing the state for `useAttachActiveFile`, better handling of interacted state
- [Any background context or related links?](https://github.com/orgs/smallcloudai/projects/5/views/1?filterQuery=alashchev+&pane=issue&itemId=81524949)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->

- Step 1: Open a new chat, select some code in editor, file preview should show file attached in format "file.ext:line1-line2", actual query for endpoint `/v1/at-command-preview` should contain query in format "file.ext:cursor_line" (can be inspected in Network tab)
- Step 2: Uncheck checkbox of file attachment, no more queries should be sent
- Step 3: Check it once more and repeat first step

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.