### PR TITLE
Fix: Checkboxes set as interacted on chat form change, if it's not empty

### DIFF
--- a/src/components/ChatForm/ChatForm.tsx
+++ b/src/components/ChatForm/ChatForm.tsx
@@ -158,7 +158,7 @@ export const ChatForm: React.FC<ChatFormProps> = ({
         handleHelpInfo(null);
       }
     },
-    [handleHelpInfo, setValue],
+    [handleHelpInfo, setValue, setFileInteracted, setLineSelectionInteracted],
   );
 
   useEffect(() => {

--- a/src/components/ChatForm/ChatForm.tsx
+++ b/src/components/ChatForm/ChatForm.tsx
@@ -77,7 +77,13 @@ export const ChatForm: React.FC<ChatFormProps> = ({
     [dispatch],
   );
 
-  const { checkboxes, onToggleCheckbox, unCheckAll } = useCheckboxes();
+  const {
+    checkboxes,
+    onToggleCheckbox,
+    unCheckAll,
+    setFileInteracted,
+    setLineSelectionInteracted,
+  } = useCheckboxes();
 
   const { previewFiles, commands, requestCompletion } =
     useCommandCompletionAndPreviewFiles(checkboxes);
@@ -144,6 +150,8 @@ export const ChatForm: React.FC<ChatFormProps> = ({
     (command: string) => {
       setValue(command);
       const trimmedCommand = command.trim();
+      setFileInteracted(!!trimmedCommand);
+      setLineSelectionInteracted(!!trimmedCommand);
       if (trimmedCommand === "@help") {
         handleHelpInfo(helpText()); // This line has been fixed
       } else {

--- a/src/components/ChatForm/useCheckBoxes.ts
+++ b/src/components/ChatForm/useCheckBoxes.ts
@@ -124,18 +124,18 @@ const useAttachSelectedSnippet = (
     });
 
   useEffect(() => {
-    // removing unnecessary check for checked state and interacted state
-    // and excluding attachedSelectedSnippet.checked from dependency array
-    setAttachedSelectedSnippet((prev) => {
-      return {
-        ...prev,
-        label: label,
-        value: markdown,
-        disabled: !snippet.code,
-        hide: host === "web",
-        checked: !!snippet.code && !interacted,
-      };
-    });
+    if (!interacted) {
+      setAttachedSelectedSnippet((prev) => {
+        return {
+          ...prev,
+          label: label,
+          value: markdown,
+          disabled: !snippet.code,
+          hide: host === "web",
+          checked: !!snippet.code && !interacted,
+        };
+      });
+    }
   }, [snippet.code, host, label, markdown, interacted]);
 
   const onToggleAttachedSelectedSnippet = useCallback(() => {


### PR DESCRIPTION
# Fix: Checkboxes set as interacted on chat form change, if it's not empty

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- Problem: Feature of remembering user's line selection and attached file was lost
- Solution: Recovering of that functionality, little adjustment on setting checkboxes as interacted. If textarea is empty, checkboxes will not remember user's selection.
- [Any background context or related links?](https://github.com/orgs/smallcloudai/projects/5/views/1?pane=issue&itemId=78566457)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.