### PR TITLE
fix(done streaming): thread maybe in the cache when generating the title

### DIFF
--- a/src/features/Chat/Thread/reducer.ts
+++ b/src/features/Chat/Thread/reducer.ts
@@ -127,6 +127,7 @@ export const chatReducer = createReducer(initialState, (builder) => {
     if (state.thread.id !== action.payload.id) return state;
     state.streaming = false;
     state.thread.read = true;
+    state.prevent_send = false;
   });
 
   builder.addCase(chatAskedQuestion, (state, action) => {
@@ -170,6 +171,7 @@ export const chatReducer = createReducer(initialState, (builder) => {
     } else {
       state.streaming = false;
     }
+    state.prevent_send = true;
     state.thread = mostUptoDateThread;
     state.thread.tool_use = state.thread.tool_use ?? state.tool_use;
   });


### PR DESCRIPTION
# Tabs done streaming

## Description

When clicking explain and away from the chat, the chat would continue to show it's streaming event when done.

Also sets prevent send so that the user decide to resume uncalled tools.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test


1. build and run vscode
2. click explain in code lens
3. navigate to history after the chat opens.
4. observe chat stop streaming when done.

## Screenshots (if applicable)


## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.

## Linked Issues


## Additional Notes
