### PR TITLE
Feature: Focusing on editor in IDE on Escape press

### DIFF
--- a/src/components/ComboBox/ComboBox.tsx
+++ b/src/components/ComboBox/ComboBox.tsx
@@ -8,7 +8,7 @@ import { Popover } from "./Popover";
 import { TruncateLeft } from "../Text";
 import { type DebouncedState } from "usehooks-ts";
 import { CommandCompletionResponse } from "../../services/refact";
-import { useAppSelector } from "../../hooks";
+import { useAppSelector, useEventsBusForIDE } from "../../hooks";
 import { selectSubmitOption } from "../../features/Config/configSlice";
 
 export type ComboBoxProps = {
@@ -37,6 +37,7 @@ export const ComboBox: React.FC<ComboBoxProps> = ({
   const ref = React.useRef<HTMLTextAreaElement>(null);
   const [moveCursorTo, setMoveCursorTo] = React.useState<number | null>(null);
   const shiftEnterToSubmit = useAppSelector(selectSubmitOption);
+  const { escapeKeyPressed } = useEventsBusForIDE();
 
   const combobox = useComboboxStore({
     defaultOpen: false,
@@ -180,11 +181,13 @@ export const ComboBox: React.FC<ComboBoxProps> = ({
 
       if (event.key === "Escape") {
         closeCombobox();
+        escapeKeyPressed("combobox");
       }
     },
     [
       onHelpClick,
       closeCombobox,
+      escapeKeyPressed,
       combobox,
       handleReplace,
       state.activeId,

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -59,6 +59,7 @@ export {
   ideAnimateFileStop,
   ideWriteResultsToFile,
   ideChatPageChange,
+  ideEscapeKeyPressed,
   ideDoneStreaming,
 } from "../hooks/useEventBusForIDE";
 

--- a/src/hooks/useEventBusForIDE.ts
+++ b/src/hooks/useEventBusForIDE.ts
@@ -42,6 +42,7 @@ export const ideWriteResultsToFile = createAction<PatchResult[]>(
 );
 
 export const ideChatPageChange = createAction<string>("ide/chatPageChange");
+export const ideEscapeKeyPressed = createAction<string>("ide/escapeKeyPressed");
 
 export const ideDoneStreaming = createAction<boolean>("ide/doneStreaming");
 
@@ -158,6 +159,14 @@ export const useEventsBusForIDE = () => {
     [postMessage],
   );
 
+  const escapeKeyPressed = useCallback(
+    (mode: string) => {
+      const action = ideEscapeKeyPressed(mode);
+      postMessage(action);
+    },
+    [postMessage],
+  );
+
   const doneStreaming = useCallback(
     (state: boolean) => {
       const action = ideDoneStreaming(state);
@@ -211,6 +220,7 @@ export const useEventsBusForIDE = () => {
     startFileAnimation,
     writeResultsToFile,
     chatPageChange,
+    escapeKeyPressed,
     doneStreaming,
   };
 };


### PR DESCRIPTION
# Feature: Focusing on editor in IDE on Escape press

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- Problem: To switch back to IDE you need to click with mouse inside of editor.
- Solution: Implementation of new handler will enhance user experience by providing an ability to switch between chat and code just with one press of Escape character.
- [[vscode] Esc in chat input box -> set focus back on IDE editor](https://refact.fibery.io/Software_Development/Task/vscode-Esc-in-chat-input-box---set-focus-back-on-IDE-editor-218)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->

- Step 1: Open a new chat
- Step 2: Press `Escape` on your keyboard (important note: you should be focused on textarea)
- Step 3: See how your active tab switched from UI to actual editor (if it exists)

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.