### PR TITLE
Fix: Title generation in background

### DIFF
--- a/src/features/History/historySlice.ts
+++ b/src/features/History/historySlice.ts
@@ -128,7 +128,7 @@ startHistoryListening({
       !lastMessage.tool_calls
     ) {
       // Getting user message
-      const firstUserMessage = state.chat.thread.messages.find(isUserMessage);
+      const firstUserMessage = thread.messages.find(isUserMessage);
       if (firstUserMessage) {
         // Checking if chat title is already generated, if not - generating it
         if (!thread.title) {


### PR DESCRIPTION
# Fix: Title generation in background

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- Problem: Title wasn't generated if streaming was finished in history view.
- Solution: First user message was captured not from relative thread, but from global state itself. Now all the logic relies on thread being initiated before user went to history view.
- [Can't create title in background](https://refact.fibery.io/Software_Development/UI-UX-133#Task/Can't-create-title-in-background-215)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->

1. Step 1: Start a new chat thread, ask anything to model
2. Step 2: After streaming has started, go to main view
3. Step 3: After finalization of model's response, chat title should be generated properly.

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.