### PR TITLE
Fix: Better errors for /v1/customization & ChatComponent refactoring

### DIFF
--- a/src/app/middleware.ts
+++ b/src/app/middleware.ts
@@ -59,13 +59,14 @@ startListening({
         : `fetching caps from lsp`;
       listenerApi.dispatch(setError(message));
     }
-
+    // do we need this?
     if (
       promptsApi.endpoints.getPrompts.matchRejected(action) &&
       !action.meta.condition
     ) {
       const message = `fetching system prompts.`;
-      listenerApi.dispatch(setError(action.error.message ?? message));
+      // action.error.message contains always "Rejected" message, not the error message from LSP
+      listenerApi.dispatch(setError(message));
     }
 
     if (

--- a/src/app/middleware.ts
+++ b/src/app/middleware.ts
@@ -40,6 +40,7 @@ startListening({
       toolsApi.util.resetApiState(),
       commandsApi.util.resetApiState(),
       diffApi.util.resetApiState(),
+      pingApi.util.resetApiState(),
     ].forEach((api) => listenerApi.dispatch(api));
 
     listenerApi.dispatch(clearError());
@@ -59,13 +60,12 @@ startListening({
         : `fetching caps from lsp`;
       listenerApi.dispatch(setError(message));
     }
-    // do we need this?
     if (
       promptsApi.endpoints.getPrompts.matchRejected(action) &&
       !action.meta.condition
     ) {
       const message = `fetching system prompts.`;
-      // action.error.message contains always "Rejected" message, not the error message from LSP
+      // action.error.message contains always "Rejected" message, not the explanation message at all
       listenerApi.dispatch(setError(message));
     }
 

--- a/src/app/middleware.ts
+++ b/src/app/middleware.ts
@@ -13,7 +13,7 @@ import { statisticsApi } from "../services/refact/statistics";
 import { capsApi, isCapsErrorResponse } from "../services/refact/caps";
 import { promptsApi } from "../services/refact/prompts";
 import { toolsApi } from "../services/refact/tools";
-import { commandsApi } from "../services/refact/commands";
+import { commandsApi, isDetailMessage } from "../services/refact/commands";
 import { diffApi } from "../services/refact/diffs";
 import { pingApi } from "../services/refact/ping";
 import { clearError, setError } from "../features/Errors/errorsSlice";
@@ -64,9 +64,11 @@ startListening({
       promptsApi.endpoints.getPrompts.matchRejected(action) &&
       !action.meta.condition
     ) {
-      const message = `fetching system prompts.`;
-      // action.error.message contains always "Rejected" message, not the explanation message at all
-      listenerApi.dispatch(setError(message));
+      // getting first 2 lines of error message to show to user
+      const errorMessage = isDetailMessage(action.payload?.data)
+        ? action.payload.data.detail.split("\n").slice(0, 2).join("\n")
+        : `fetching system prompts.`;
+      listenerApi.dispatch(setError(errorMessage));
     }
 
     if (

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -6,6 +6,7 @@ import {
   useAppSelector,
   useAppDispatch,
   useSendChatRequest,
+  useGetPromptsQuery,
 } from "../../hooks";
 import type { Config } from "../../features/Config/configSlice";
 import {
@@ -18,9 +19,12 @@ import {
   selectChatId,
   selectMessages,
   getSelectedToolUse,
+  getSelectedSystemPrompt,
+  setSystemPrompt,
 } from "../../features/Chat/Thread";
 import { ThreadHistoryButton } from "../Buttons";
 import { push } from "../../features/Pages/pagesSlice";
+import { SystemPrompts } from "../../services/refact";
 
 export type ChatProps = {
   host: Config["host"];
@@ -31,9 +35,6 @@ export type ChatProps = {
   // TODO: update this
   caps: ChatFormProps["caps"];
   maybeSendToSidebar: ChatFormProps["onClose"];
-  prompts: ChatFormProps["prompts"];
-  onSetSystemPrompt: ChatFormProps["onSetSystemPrompt"];
-  selectedSystemPrompt: ChatFormProps["selectedSystemPrompt"];
 };
 
 export const Chat: React.FC<ChatProps> = ({
@@ -41,9 +42,6 @@ export const Chat: React.FC<ChatProps> = ({
   unCalledTools,
   caps,
   maybeSendToSidebar,
-  prompts,
-  onSetSystemPrompt,
-  selectedSystemPrompt,
 }) => {
   const [isViewingRawJSON, setIsViewingRawJSON] = useState(false);
   const chatContentRef = useRef<HTMLDivElement>(null);
@@ -57,6 +55,10 @@ export const Chat: React.FC<ChatProps> = ({
   const dispatch = useAppDispatch();
   const messages = useAppSelector(selectMessages);
 
+  const promptsRequest = useGetPromptsQuery();
+  const selectedSystemPrompt = useAppSelector(getSelectedSystemPrompt);
+  const onSetSelectedSystemPrompt = (prompt: SystemPrompts) =>
+    dispatch(setSystemPrompt(prompt));
   const [isDebugChatHistoryVisible, setIsDebugChatHistoryVisible] =
     useState(false);
 
@@ -148,8 +150,8 @@ export const Chat: React.FC<ChatProps> = ({
         onStopStreaming={abort}
         onClose={maybeSendToSidebar}
         onTextAreaHeightChange={onTextAreaHeightChange}
-        prompts={prompts}
-        onSetSystemPrompt={onSetSystemPrompt}
+        prompts={promptsRequest.data ?? {}}
+        onSetSystemPrompt={onSetSelectedSystemPrompt}
         selectedSystemPrompt={selectedSystemPrompt}
       />
       <Flex justify="between" pl="1" pr="1" pt="1">

--- a/src/features/Chat/Chat.tsx
+++ b/src/features/Chat/Chat.tsx
@@ -1,18 +1,9 @@
 import React from "react";
 import type { Config } from "../Config/configSlice";
-import { SystemPrompts } from "../../services/refact";
 import { Chat as ChatComponent } from "../../components/Chat";
-import {
-  useGetPromptsQuery,
-  useAppDispatch,
-  useAppSelector,
-} from "../../hooks";
+import { useAppSelector } from "../../hooks";
 import { useGetCapsQuery } from "../../hooks/useGetCapsQuery";
-import {
-  getSelectedSystemPrompt,
-  setSystemPrompt,
-  selectMessages,
-} from "./Thread";
+import { selectMessages } from "./Thread";
 
 export type ChatProps = {
   host: Config["host"];
@@ -28,13 +19,6 @@ export const Chat: React.FC<ChatProps> = ({
   tabbed,
 }) => {
   const capsRequest = useGetCapsQuery();
-
-  // TODO: these could be lower in the component tree
-  const promptsRequest = useGetPromptsQuery();
-  const selectedSystemPrompt = useAppSelector(getSelectedSystemPrompt);
-  const dispatch = useAppDispatch();
-  const onSetSelectedSystemPrompt = (prompt: SystemPrompts) =>
-    dispatch(setSystemPrompt(prompt));
 
   const messages = useAppSelector(selectMessages);
 
@@ -70,10 +54,6 @@ export const Chat: React.FC<ChatProps> = ({
         available_caps: capsRequest.data?.code_chat_models ?? {},
       }}
       maybeSendToSidebar={maybeSendToSideBar}
-      prompts={promptsRequest.data ?? {}}
-      // Could be lowered
-      onSetSystemPrompt={onSetSelectedSystemPrompt}
-      selectedSystemPrompt={selectedSystemPrompt}
       // TODO: This can be removed
       // requestPreviewFiles={() => ({})}
     />

--- a/src/services/refact/prompts.ts
+++ b/src/services/refact/prompts.ts
@@ -1,5 +1,4 @@
 import { RootState } from "../../app/store";
-import { setError } from "../../features/Errors/errorsSlice";
 import { CUSTOM_PROMPTS_URL } from "./consts";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
@@ -29,17 +28,6 @@ export const promptsApi = createApi({
           redirect: "follow",
         });
         if (result.error) {
-          if (!isDetailMessage(result.error.data)) {
-            return {
-              error: result.error,
-            };
-          }
-          // getting first 2 lines of error message to show to user
-          const errorMessage = result.error.data.detail
-            .split("\n")
-            .slice(0, 2)
-            .join("\n");
-          api.dispatch(setError(errorMessage));
           return {
             error: result.error,
           };
@@ -100,12 +88,4 @@ export function isCustomPromptsResponse(
   if (typeof json.system_prompts !== "object") return false;
   if (json.system_prompts === null) return false;
   return isSystemPrompts(json.system_prompts);
-}
-
-type DetailMessage = { detail: string };
-// TODO: importing isDetailMessage from features/Chat/Thread/types seems to completely crash redux store
-function isDetailMessage(json: unknown): json is DetailMessage {
-  if (!json) return false;
-  if (typeof json !== "object") return false;
-  return "detail" in json && typeof json.detail === "string";
 }

--- a/src/services/refact/prompts.ts
+++ b/src/services/refact/prompts.ts
@@ -103,7 +103,7 @@ export function isCustomPromptsResponse(
 }
 
 type DetailMessage = { detail: string };
-
+// TODO: importing isDetailMessage from features/Chat/Thread/types seems to completely crash redux store
 function isDetailMessage(json: unknown): json is DetailMessage {
   if (!json) return false;
   if (typeof json !== "object") return false;

--- a/src/services/refact/prompts.ts
+++ b/src/services/refact/prompts.ts
@@ -1,6 +1,11 @@
 import { RootState } from "../../app/store";
+import { setError } from "../../features/Errors/errorsSlice";
 import { CUSTOM_PROMPTS_URL } from "./consts";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+
+type CustomizationErrorResponse = {
+  detail?: string;
+};
 
 export const promptsApi = createApi({
   reducerPath: "prompts",
@@ -27,7 +32,19 @@ export const promptsApi = createApi({
           credentials: "same-origin",
           redirect: "follow",
         });
-        if (result.error) return { error: result.error };
+        if (result.error) {
+          // getting first 2 lines of error message to show to user
+          const errorMessage = (
+            result.error.data as CustomizationErrorResponse
+          ).detail
+            ?.split("\n")
+            .slice(0, 2)
+            .join("\n");
+          api.dispatch(setError(errorMessage ?? "fetching system prompts."));
+          return {
+            error: result.error,
+          };
+        }
         if (!isCustomPromptsResponse(result.data)) {
           return {
             error: {


### PR DESCRIPTION
# Fix: Better errors for /v1/customization & ChatComponent refactoring

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- Problem: On `/v1/customization` fetch, error message was set by middleware and not from actual query. Also, prop drilling was present from `features/Chat.tsx` component.
- Solution: Setting error message directly in query function, reduction of prop drilling by moving selectors deeper in components tree
- [Bad error message on syntax error in customization.yaml](https://refact.fibery.io/Software_Development/Task/Bad-error-message-on-syntax-error-in-customization.yaml-219)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->

1. Step 1: Add to your `customization.yaml` some illegal code, for example: `aaaaa aaaaa"`
2. Step 2: Try to open a new chat
3. Step 3: Better error message should appear

## Screenshots (if applicable)

<!-- If your changes include UI modifications, attach relevant screenshots here. -->

### Better error for `v1/customization`
![Better error for `v1/customization`](https://github.com/user-attachments/assets/54cacce9-6d08-4f7e-a781-dd0e3960096e)

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.