### PR TITLE
Fix: Title generation in background after resuming of chat

### DIFF
--- a/src/__fixtures__/chat.ts
+++ b/src/__fixtures__/chat.ts
@@ -64,6 +64,7 @@ export const MARS_ROVER_CHAT: ChatHistoryItem = {
     { role: "user", content: "long message\n" + "a".repeat(10000) },
   ],
   title: "mars rover kata",
+  isTitleGenerated: true,
   model: "gpt-3.5-turbo",
   tool_use: "explore",
   createdAt: "2023-12-21T17:32:50.186Z",

--- a/src/__fixtures__/history.ts
+++ b/src/__fixtures__/history.ts
@@ -27,6 +27,7 @@ export const HISTORY: ChatHistoryItem[] = [
     title:
       "Write a program that solves word-chain puzzles.\n\nThere’s a type of puzzle where the challenge is to build a chain of words, starting with one particular word and ending with another. Successive entries in the chain must all be real words, and each can differ from the previous word by just one letter. For example, you can get from “cat” to “dog” using the following chain.\n",
     model: "",
+    isTitleGenerated: true,
     createdAt: "2024-07-02T10:43:13.401Z",
     updatedAt: "2024-07-02T10:44:38.325Z",
     tool_use: "explore",
@@ -113,6 +114,7 @@ export const HISTORY: ChatHistoryItem[] = [
     title:
       "In this project, what is the difference between a toad and a frog?\n",
     model: "",
+    isTitleGenerated: true,
     createdAt: "2024-07-02T10:40:27.354Z",
     updatedAt: "2024-07-02T10:40:32.341Z",
     tool_use: "explore",

--- a/src/__tests__/DeleteChat.test.tsx
+++ b/src/__tests__/DeleteChat.test.tsx
@@ -11,6 +11,7 @@ describe("Delete a Chat form history", () => {
     const history: HistoryState = {
       abc123: {
         title: "Test title",
+        isTitleGenerated: false,
         messages: [],
         id: "abc123",
         model: "foo",

--- a/src/__tests__/RestoreChat.test.tsx
+++ b/src/__tests__/RestoreChat.test.tsx
@@ -30,6 +30,7 @@ describe("Restore Chat from history", () => {
         history: {
           id: {
             title: "test title",
+            isTitleGenerated: true,
             id: "id",
             createdAt: "0",
             updatedAt: "0",

--- a/src/features/Chat/Thread/actions.ts
+++ b/src/features/Chat/Thread/actions.ts
@@ -129,7 +129,9 @@ export const chatGenerateTitleThunk = createAppAsyncThunk<
       const cleanedTitle = title.replace(/"/g, "");
 
       // Dispatching saveTitle action for a chatThread
-      thunkAPI.dispatch(saveTitle({ id: chatId, title: cleanedTitle }));
+      thunkAPI.dispatch(
+        saveTitle({ id: chatId, title: cleanedTitle, isTitleGenerated: true }),
+      );
       return { title: cleanedTitle, chatId: state.chat.thread.id };
     })
     .catch((err: Error) => {

--- a/src/features/Chat/Thread/reducer.ts
+++ b/src/features/Chat/Thread/reducer.ts
@@ -180,5 +180,6 @@ export const chatReducer = createReducer(initialState, (builder) => {
   builder.addCase(saveTitle, (state, action) => {
     if (state.thread.id !== action.payload.id) return state;
     state.thread.title = action.payload.title;
+    state.thread.isTitleGenerated = action.payload.isTitleGenerated;
   });
 });

--- a/src/features/Chat/Thread/types.ts
+++ b/src/features/Chat/Thread/types.ts
@@ -11,6 +11,7 @@ export type ChatThread = {
   updatedAt?: string;
   tool_use?: ToolUse;
   read?: boolean;
+  isTitleGenerated?: boolean;
 };
 
 export type ToolUse = "quick" | "explore" | "agent";
@@ -28,7 +29,10 @@ export type Chat = {
 };
 
 export type PayloadWithId = { id: string };
-export type PayloadWithIdAndTitle = { title: string } & PayloadWithId;
+export type PayloadWithIdAndTitle = {
+  title: string;
+  isTitleGenerated: boolean;
+} & PayloadWithId;
 
 export type DetailMessage = { detail: string };
 


### PR DESCRIPTION
# Fix: Title generation in background after resuming of chat

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- Problem: After resuming of chat with uncalled tools previously, title wasn't generated.
- Solution: Additional flag of `isTitleGenerated` and updated logic for title generation
- [Can't create title in background](https://refact.fibery.io/Software_Development/Task/Can't-create-title-in-background-215)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->

- Step 1: Use CodeLens 'Explain' of 'Find Problems' with `auto_submit` flag set to `true`
- Step 2: Immediately go to history view page, where all chat threads are located
- Step 3: Return to the chat when streaming is done
- Step 4: Click on 'Resume' to continue response generation coming from model
- Step 5: Go to history view again, wait for the end of streaming
- Step 6: If model didn't try to call any tools, title should be generated correctly. If model called tools, go back to step 3

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.