### PR TITLE
wip(tool loop): set `onlyDeterministicMessages` if a duplicate tool call and result is found.

### DIFF
--- a/src/features/Chat/Thread/actions.ts
+++ b/src/features/Chat/Thread/actions.ts
@@ -8,7 +8,10 @@ import {
 import {
   isAssistantMessage,
   isChatGetTitleResponse,
+  isToolCallMessage,
   isToolMessage,
+  ToolCall,
+  ToolMessage,
   type ChatMessages,
   type ChatResponse,
 } from "../../../services/refact/types";
@@ -17,6 +20,7 @@ import type { SystemPrompts } from "../../../services/refact/prompts";
 import { formatMessagesForLsp, consumeStream } from "./utils";
 import { generateChatTitle, sendChat } from "../../../services/refact/chat";
 import { ToolCommand } from "../../../services/refact/tools";
+import { scanFoDuplicatesWith, takeFromEndWhile } from "../../../utils";
 
 export const newChatAction = createAction("chatThread/new");
 
@@ -141,6 +145,45 @@ export const chatGenerateTitleThunk = createAppAsyncThunk<
     });
 });
 
+function checkForToolLoop(message: ChatMessages): boolean {
+  const assistantOrToolMessages = takeFromEndWhile(message, (message) => {
+    return isToolMessage(message) || isToolCallMessage(message);
+  });
+
+  if (assistantOrToolMessages.length === 0) return false;
+
+  const toolCalls = assistantOrToolMessages.reduce<ToolCall[]>((acc, cur) => {
+    if (!isToolCallMessage(cur)) return acc;
+    return acc.concat(cur.tool_calls);
+  }, []);
+
+  if (toolCalls.length === 0) return false;
+
+  const toolResults = assistantOrToolMessages.filter((message) =>
+    isToolMessage(message),
+  );
+
+  const hasDuplicates = scanFoDuplicatesWith(toolCalls, (a, b) => {
+    const aResult: ToolMessage | undefined = toolResults.find(
+      (message) => message.content.tool_call_id === a.id,
+    );
+
+    const bResult: ToolMessage | undefined = toolResults.find(
+      (message) => message.content.tool_call_id === b.id,
+    );
+
+    return (
+      a.function.name === b.function.name &&
+      a.function.arguments === b.function.arguments &&
+      !!aResult &&
+      !!bResult &&
+      aResult.content.content === bResult.content.content
+    );
+  });
+
+  return hasDuplicates;
+}
+
 export const chatAskQuestionThunk = createAppAsyncThunk<
   unknown,
   {
@@ -151,7 +194,12 @@ export const chatAskQuestionThunk = createAppAsyncThunk<
 >("chatThread/sendChat", ({ messages, chatId, tools }, thunkAPI) => {
   const state = thunkAPI.getState();
 
+  const onlyDeterministicMessages = checkForToolLoop(messages);
+
   const messagesForLsp = formatMessagesForLsp(messages);
+
+  console.log({ onlyDeterministicMessages });
+
   return sendChat({
     messages: messagesForLsp,
     model: state.chat.thread.model,
@@ -161,6 +209,7 @@ export const chatAskQuestionThunk = createAppAsyncThunk<
     chatId,
     apiKey: state.config.apiKey,
     port: state.config.lspPort,
+    onlyDeterministicMessages,
   })
     .then((response) => {
       if (!response.ok) {

--- a/src/features/Chat/Thread/actions.ts
+++ b/src/features/Chat/Thread/actions.ts
@@ -159,9 +159,7 @@ function checkForToolLoop(message: ChatMessages): boolean {
 
   if (toolCalls.length === 0) return false;
 
-  const toolResults = assistantOrToolMessages.filter((message) =>
-    isToolMessage(message),
-  );
+  const toolResults = assistantOrToolMessages.filter(isToolMessage);
 
   const hasDuplicates = scanFoDuplicatesWith(toolCalls, (a, b) => {
     const aResult: ToolMessage | undefined = toolResults.find(
@@ -197,8 +195,6 @@ export const chatAskQuestionThunk = createAppAsyncThunk<
   const onlyDeterministicMessages = checkForToolLoop(messages);
 
   const messagesForLsp = formatMessagesForLsp(messages);
-
-  console.log({ onlyDeterministicMessages });
 
   return sendChat({
     messages: messagesForLsp,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,3 +4,5 @@ export * from "./trimIndent";
 export * from "./filename";
 export * from "./parseOrElse";
 export * from "./takeWhile";
+export * from "./takeFromEndWhile";
+export * from "./scanForDuplicates";

--- a/src/utils/scanForDuplicates.ts
+++ b/src/utils/scanForDuplicates.ts
@@ -1,0 +1,11 @@
+export function scanFoDuplicatesWith<T>(
+  arr: T[],
+  predicate: (a: T, b: T) => boolean,
+): boolean {
+  if (arr.length === 0) return false;
+  if (arr.length === 1) return false;
+  const [head, ...tail] = arr;
+  const hasDuplicate = tail.some((item) => predicate(head, item));
+  if (hasDuplicate) return true;
+  return scanFoDuplicatesWith(tail, predicate);
+}

--- a/src/utils/takeFromEndWhile.ts
+++ b/src/utils/takeFromEndWhile.ts
@@ -1,0 +1,20 @@
+function iter<T>(
+  arr: T[],
+  predicate: (item: T) => boolean,
+  acc: T[] = [],
+): T[] {
+  if (arr.length === 0) return acc;
+
+  const head = arr.slice(-1)[0];
+  if (!predicate(head)) return acc;
+
+  const tail = arr.slice(0, -1);
+  return iter(tail, predicate, [head, ...acc]);
+}
+
+export function takeFromEndWhile<T>(
+  arr: T[],
+  predicate: (item: T) => boolean,
+): T[] {
+  return iter(arr, predicate);
+}

--- a/src/utils/utils.test.tsx
+++ b/src/utils/utils.test.tsx
@@ -1,5 +1,12 @@
 import { describe, test, expect } from "vitest";
-import { trimIndentFromMarkdown, trimIndent, filename, parseOrElse } from ".";
+import {
+  trimIndentFromMarkdown,
+  trimIndent,
+  filename,
+  parseOrElse,
+  takeFromEndWhile,
+  scanFoDuplicatesWith,
+} from ".";
 
 const spaces = "    ";
 describe("trim indent from markdown", () => {
@@ -79,4 +86,31 @@ describe("parseOrElse", () => {
       expect(result).toEqual(expected);
     },
   );
+});
+
+describe("takeFromEndWhile", () => {
+  const tests = [
+    [
+      ["a", "a", "b", "a", "b", "b"],
+      ["b", "b"],
+    ],
+    [["a", "b", "b", "c"], []],
+  ];
+
+  test.each(tests)("when given %s it should return %s", (input, expected) => {
+    const result = takeFromEndWhile(input, (char) => char === "b");
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("scanForDuplicates", () => {
+  const tests: [string[], boolean][] = [
+    [["a", "b", "c", "d", "b", "e"], true],
+    [["a", "b", "c", "d", "e"], false],
+  ];
+
+  test.each(tests)("when given %s it should return %b", (input, expected) => {
+    const result = scanFoDuplicatesWith(input, (a, b) => a === b);
+    expect(result).toEqual(expected);
+  });
 });

--- a/src/utils/utils.test.tsx
+++ b/src/utils/utils.test.tsx
@@ -94,11 +94,18 @@ describe("takeFromEndWhile", () => {
       ["a", "a", "b", "a", "b", "b"],
       ["b", "b"],
     ],
-    [["a", "b", "b", "c"], []],
+    [["a", "b", "c", "d"], []],
+    [
+      ["a", "b", "c", "b", "b"],
+      ["b", "c", "b", "b"],
+    ],
   ];
 
   test.each(tests)("when given %s it should return %s", (input, expected) => {
-    const result = takeFromEndWhile(input, (char) => char === "b");
+    const result = takeFromEndWhile(
+      input,
+      (char) => char === "b" || char === "c",
+    );
     expect(result).toEqual(expected);
   });
 });


### PR DESCRIPTION
# Prevent Tool Loop

## Description

Tool calls can create a loop, it usually happens when using `cat` a lot.

setting `only_deterministic_messages` on the request to `v1/chat` will stop this loop.

This PR scans the messages to see if it ends with a sequence of `assistant` and `tool` messages, then checks those messages to see if `function.name`, `function.arguments`, and `tool.content` are duplicated inn another message.

if there is a duplicate, the `only_deterministic_messages` property is set to true. and the loop stops.

TODO:
We might want to notify the user that the their was a loop.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->

1. Start the lsp with the workspace `-w` set to the directory of the lsp source code. `-w .`
* open the network tabs.
2. Open chat and ask gpt-4o-mini  to `add a swim method` with the explore tools
3. this could cause a loop, now it will stop. 
4. resubmit this question until  it uses the tools.
5. change the networks tab, and the last request to `/v1/chat` should have the `only_deterministic_messages` flag set.

## Screenshots (if applicable)


## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.

## Linked Issues

Ticket: https://refact.fibery.io/Software_Development/UI-UX-133#Task/Infinite-loop-in-chat-238

## Additional Notes

Could these checks be done in the lsp ?
