### PR TITLE
Fix/diff new line

### DIFF
--- a/src/components/Markdown/CodeBlock.tsx
+++ b/src/components/Markdown/CodeBlock.tsx
@@ -32,7 +32,7 @@ const _MarkdownCodeBlock: React.FC<MarkdownCodeBlockProps> = ({
 }) => {
   const codeRef = React.useRef<HTMLElement | null>(null);
   const match = /language-(\w+)/.exec(className ?? "");
-  const textWithOutTrailingNewLine = String(children); //.replace(/\n$/, "");
+  const textWithOutTrailingNewLine = String(children).replace(/\n$/, "");
   const textWithOutIndent = trimIndent(textWithOutTrailingNewLine);
 
   const preTagProps: PreTagProps = onCopyClick


### PR DESCRIPTION
# Fixes vscode adding a newline when clicking "replace selection"

## Description

Click "replace selection" adds a new line

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->

1. Checkout https://github.com/smallcloudai/refact-vscode/pull/162
2. ask chat a question that crates a code block
3. In vscode highlight an area to replace
4. Click `replace selection` 
5. It should not add a new line


## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.

## Linked Issues

https://refact.fibery.io/Software_Development/UI-UX-133#Task/Diff-adds-empty-lines-226

## Additional Notes

