### PR TITLE
Tools: group diffs and tool results, but not tool_calls

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -14,13 +14,13 @@ const preview: Preview = {
     },
     layout: "fullscreen",
   },
-  decorators: [
-    (Page) => (
-      <Theme accentColor="gray">
-        <Page />
-      </Theme>
-    ),
-  ],
+  // decorators: [
+  //   (Page) => (
+  //     <Theme accentColor="gray">
+  //       <Page />
+  //     </Theme>
+  //   ),
+  // ],
 };
 
 export default preview;

--- a/src/__fixtures__/chat.ts
+++ b/src/__fixtures__/chat.ts
@@ -787,10 +787,49 @@ export const LARGE_DIFF: ChatThread = {
     },
     {
       role: "assistant",
+      content: "",
+      tool_calls: [
+        {
+          function: {
+            arguments:
+              '{"path":"/Users/marc/Projects/refact-lsp/tests/emergency_frog_situation/frog.py","todo":"Add an \'edible\' property to the Frog class and initialize it in the constructor."}',
+            name: "patch",
+          },
+          id: "call_dIXVNlzugvrPJvTF5G7n1YgK",
+          index: 0,
+          type: "function",
+        },
+      ],
+    },
+    {
+      role: "diff",
+      content: [
+        {
+          file_action: "edit",
+          file_name:
+            "/Users/marc/Projects/refact-lsp/tests/emergency_frog_situation/frog.py",
+          line1: 1,
+          line2: 1,
+          lines_add:
+            "class Frog:\n    def __init__(self, x, y, vx, vy):\n        self.x = x\n        self.y = y\n        self.vx = vx\n        self.vy = vy\n        self.edible = True",
+          lines_remove:
+            "class Frog:\n    def __init__(self, x, y, vx, vy):\n        self.x = x\n        self.y = y\n        self.vx = vx\n        self.vy = vy",
+        },
+      ],
+      tool_call_id: "call_dIXVNlzugvrPJvTF5G7n1YgK",
+    },
+    {
+      role: "assistant",
       content:
-        "The class `Frog` has been successfully renamed to `Bird` and all its references have been updated accordingly in the following files:\n\n- `frog.py`\n- `set_as_avatar.py`\n- `jump_to_conclusions.py`\n- `work_day.py`\n- `holiday.py`\n\nIs there anything else you need help with?",
+        "The `Frog` class has been updated to include an `edible` property.",
       tool_calls: null,
     },
+    // {
+    //   role: "assistant",
+    //   content:
+    //     "The class `Frog` has been successfully renamed to `Bird` and all its references have been updated accordingly in the following files:\n\n- `frog.py`\n- `set_as_avatar.py`\n- `jump_to_conclusions.py`\n- `work_day.py`\n- `holiday.py`\n\nIs there anything else you need help with?",
+    //   tool_calls: null,
+    // },
   ],
   title: "rename the frog class to bird.\n",
   model: "gpt-4o",

--- a/src/components/ChatContent/ChatContent.stories.tsx
+++ b/src/components/ChatContent/ChatContent.stories.tsx
@@ -1,11 +1,69 @@
+import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { ChatContent } from ".";
+import { Provider } from "react-redux";
+import { setUpStore } from "../../app/store";
+import { Theme } from "../Theme";
+import { AbortControllerProvider } from "../../contexts/AbortControllers";
+import { MarkdownMessage } from "../../__fixtures__/markdown";
+import { ChatMessages } from "../../events";
+import {
+  CHAT_FUNCTIONS_MESSAGES,
+  CHAT_WITH_DIFF_ACTIONS,
+  CHAT_WITH_DIFFS,
+  FROG_CHAT,
+  LARGE_DIFF,
+} from "../../__fixtures__";
+
+const MockedStore: React.FC<{
+  messages: ChatMessages;
+}> = ({ messages }) => {
+  const store = setUpStore({
+    chat: {
+      streaming: false,
+      prevent_send: false,
+      waiting_for_response: false,
+      tool_use: "quick",
+      send_immediately: false,
+      error: null,
+      cache: {},
+      system_prompt: {},
+      thread: {
+        id: "test",
+        model: "test",
+        messages,
+      },
+    },
+  });
+  return (
+    <Provider store={store}>
+      <Theme>
+        <AbortControllerProvider>
+          <ChatContent onRetry={() => ({})} />
+        </AbortControllerProvider>
+      </Theme>
+    </Provider>
+  );
+};
 
 const meta = {
   title: "Chat Content",
-  component: ChatContent,
-  args: {},
-} satisfies Meta<typeof ChatContent>;
+  component: MockedStore,
+  args: {
+    messages: [],
+  },
+  // decorators: [
+  //   (Story) => (
+  //     <Provider store={store}>
+  //       <Theme>
+  //         <AbortControllerProvider>
+  //           <Story />
+  //         </AbortControllerProvider>
+  //       </Theme>
+  //     </Provider>
+  //   ),
+  // ],
+} satisfies Meta<typeof MockedStore>;
 
 export default meta;
 
@@ -16,32 +74,32 @@ export const Primary: Story = {};
 export const WithFunctions: Story = {
   args: {
     ...meta.args,
-    // messages: CHAT_FUNCTIONS_MESSAGES,
+    messages: CHAT_FUNCTIONS_MESSAGES,
   },
 };
 
 export const Notes: Story = {
   args: {
-    // messages: FROG_CHAT.messages,
+    messages: FROG_CHAT.messages,
   },
 };
 
 export const WithDiffs: Story = {
   args: {
-    // messages: CHAT_WITH_DIFFS,
+    messages: CHAT_WITH_DIFFS,
   },
 };
 
-export const WithDiffActions = {
+export const WithDiffActions: Story = {
   args: {
-    // messages: CHAT_WITH_DIFF_ACTIONS.messages,
+    messages: CHAT_WITH_DIFF_ACTIONS.messages,
     // getDiffByIndex: (key: string) => CHAT_WITH_DIFF_ACTIONS.applied_diffs[key],
   },
 };
 
-export const LargeDiff = {
+export const LargeDiff: Story = {
   args: {
-    // messages: LARGE_DIFF.messages,
+    messages: LARGE_DIFF.messages,
     // getDiffByIndex: (key: string) => LARGE_DIFF.applied_diffs[key],
   },
 };
@@ -50,19 +108,11 @@ export const Empty: Story = {
   args: {
     ...meta.args,
   },
-  decorators: [
-    // TODO: use redux store
-    (Story) => (
-      // <ConfigProvider config={{ host: "ide" }}>
-      <Story />
-      // </ConfigProvider>
-    ),
-  ],
 };
 
 export const AssistantMarkdown: Story = {
   args: {
     ...meta.args,
-    // messages: [["assistant", MarkdownTest]],
+    messages: [{ role: "assistant", content: MarkdownMessage }],
   },
 };

--- a/src/components/ChatContent/ChatContent.stories.tsx
+++ b/src/components/ChatContent/ChatContent.stories.tsx
@@ -35,6 +35,7 @@ const MockedStore: React.FC<{
       },
     },
   });
+
   return (
     <Provider store={store}>
       <Theme>
@@ -52,17 +53,6 @@ const meta = {
   args: {
     messages: [],
   },
-  // decorators: [
-  //   (Story) => (
-  //     <Provider store={store}>
-  //       <Theme>
-  //         <AbortControllerProvider>
-  //           <Story />
-  //         </AbortControllerProvider>
-  //       </Theme>
-  //     </Provider>
-  //   ),
-  // ],
 } satisfies Meta<typeof MockedStore>;
 
 export default meta;

--- a/src/components/ChatContent/ChatContent.tsx
+++ b/src/components/ChatContent/ChatContent.tsx
@@ -1,10 +1,8 @@
 import React, { useCallback, useEffect } from "react";
 import {
   ChatMessages,
-  isAssistantMessage,
   isChatContextFileMessage,
   isDiffMessage,
-  isToolMessage,
 } from "../../services/refact";
 import { UserInput } from "./UserInput";
 import { ScrollArea } from "../ScrollArea";
@@ -214,15 +212,17 @@ function renderMessages(
   }
 
   if (isDiffMessage(head)) {
-    const restInTail = takeWhile(tail, (message) => {
-      const isEmptyAssistantMessage =
-        isAssistantMessage(message) && !message.content;
-      return (
-        isDiffMessage(message) ||
-        isToolMessage(message) ||
-        isEmptyAssistantMessage
-      );
-    });
+    // const restInTail = takeWhile(tail, (message) => {
+    //   const isEmptyAssistantMessage =
+    //     isAssistantMessage(message) && !message.content;
+    //   return (
+    //     isDiffMessage(message) ||
+    //     isToolMessage(message) ||
+    //     isEmptyAssistantMessage
+    //   );
+    // });
+
+    const restInTail = takeWhile(tail, isDiffMessage);
 
     const nextTail = tail.slice(restInTail.length);
     const diffMessages = [head, ...restInTail.filter(isDiffMessage)];

--- a/src/components/ChatContent/ChatContent.tsx
+++ b/src/components/ChatContent/ChatContent.tsx
@@ -3,6 +3,7 @@ import {
   ChatMessages,
   isChatContextFileMessage,
   isDiffMessage,
+  isToolMessage,
 } from "../../services/refact";
 import { UserInput } from "./UserInput";
 import { ScrollArea } from "../ScrollArea";
@@ -212,17 +213,9 @@ function renderMessages(
   }
 
   if (isDiffMessage(head)) {
-    // const restInTail = takeWhile(tail, (message) => {
-    //   const isEmptyAssistantMessage =
-    //     isAssistantMessage(message) && !message.content;
-    //   return (
-    //     isDiffMessage(message) ||
-    //     isToolMessage(message) ||
-    //     isEmptyAssistantMessage
-    //   );
-    // });
-
-    const restInTail = takeWhile(tail, isDiffMessage);
+    const restInTail = takeWhile(tail, (message) => {
+      return isDiffMessage(message) || isToolMessage(message);
+    });
 
     const nextTail = tail.slice(restInTail.length);
     const diffMessages = [head, ...restInTail.filter(isDiffMessage)];


### PR DESCRIPTION
# Ungroup diffs and tools

## Description

when finding a diff message, `{role: "assistant", content: "", tool_calls[{....}]` would be skipped.

```ts
const restInTail = takeWhile(tail, (message) => {
  const isEmptyAssistantMessage =
    isAssistantMessage(message) && !message.content;
  return (
    isDiffMessage(message) ||
    isToolMessage(message) ||
    isEmptyAssistantMessage
  );
});
```

This would hide some of the tool messages

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

Check in story book

## Screenshots (if applicable)


## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.

## Linked Issues

https://refact.fibery.io/Software_Development/UI-UX-133#Task/One-of-two-patch()-calls-visible-320


## Additional Notes
