### PR TITLE
Fix: ToolsContent overflow issue

### DIFF
--- a/src/components/ChatContent/ToolsContent.tsx
+++ b/src/components/ChatContent/ToolsContent.tsx
@@ -8,12 +8,26 @@ import { Chevron } from "../Collapsible";
 import { Reveal } from "../Reveal";
 import { useAppSelector } from "../../hooks";
 import { selectToolResultById } from "../../features/Chat/Thread/selectors";
+import { ScrollArea } from "../ScrollArea";
 
-const Result: React.FC<{ children: string }> = ({ children }) => {
+type ResultProps = {
+  children: string;
+  isInsideScrollArea?: boolean;
+};
+
+const Result: React.FC<ResultProps> = ({
+  children,
+  isInsideScrollArea = false,
+}) => {
   const lines = children.split("\n");
   return (
     <Reveal defaultOpen={lines.length < 9}>
-      <ResultMarkdown className={styles.tool_result}>{children}</ResultMarkdown>
+      <ResultMarkdown
+        className={styles.tool_result}
+        isInsideScrollArea={isInsideScrollArea}
+      >
+        {children}
+      </ResultMarkdown>
     </Reveal>
   );
 };
@@ -56,8 +70,18 @@ const ToolMessage: React.FC<{
 
   return (
     <Flex direction="column">
-      <CommandMarkdown>{functionCalled}</CommandMarkdown>
-      <Result>{"```\n" + escapedBackticks + "\n```"}</Result>
+      <ScrollArea scrollbars="horizontal" style={{ width: "100%" }}>
+        <Box>
+          <CommandMarkdown isInsideScrollArea>{functionCalled}</CommandMarkdown>
+        </Box>
+      </ScrollArea>
+      <ScrollArea scrollbars="horizontal" style={{ width: "100%" }} asChild>
+        <Box>
+          <Result isInsideScrollArea>
+            {"```\n" + escapedBackticks + "\n```"}
+          </Result>
+        </Box>
+      </ScrollArea>
     </Flex>
   );
 };
@@ -118,13 +142,7 @@ export const ToolContent: React.FC<{
 
   return (
     <Container>
-      <Collapsible.Root
-        open={open}
-        onOpenChange={setOpen}
-        style={{
-          overflow: "hidden",
-        }}
-      >
+      <Collapsible.Root open={open} onOpenChange={setOpen}>
         <Collapsible.Trigger asChild>
           <Flex gap="2" align="end">
             <Flex gap="1" align="start" direction="column">

--- a/src/components/ChatContent/ToolsContent.tsx
+++ b/src/components/ChatContent/ToolsContent.tsx
@@ -118,7 +118,13 @@ export const ToolContent: React.FC<{
 
   return (
     <Container>
-      <Collapsible.Root open={open} onOpenChange={setOpen}>
+      <Collapsible.Root
+        open={open}
+        onOpenChange={setOpen}
+        style={{
+          overflow: "hidden",
+        }}
+      >
         <Collapsible.Trigger asChild>
           <Flex gap="2" align="end">
             <Flex gap="1" align="start" direction="column">

--- a/src/components/Command/Command.module.css
+++ b/src/components/Command/Command.module.css
@@ -15,3 +15,7 @@
   background: none;
   padding: 0;
 }
+
+.isInsideScrollArea {
+  width: fit-content;
+}

--- a/src/components/Command/Markdown.tsx
+++ b/src/components/Command/Markdown.tsx
@@ -19,16 +19,20 @@ type CodeBlockProps = React.JSX.IntrinsicElements["code"] & {
 export type MarkdownProps = {
   children: string;
   className?: string;
+  isInsideScrollArea?: boolean;
 } & Pick<CodeBlockProps, "showLineNumbers" | "startingLineNumber" | "style">;
 
 export const Markdown: React.FC<MarkdownProps> = ({
   children,
   className,
+  isInsideScrollArea,
   style = hljsStyle,
 }) => {
   return (
     <ReactMarkdown
-      className={classNames(styles.markdown, className)}
+      className={classNames(styles.markdown, className, {
+        [styles.isInsideScrollArea]: isInsideScrollArea,
+      })}
       components={{
         code({ color: _color, ref: _ref, node: _node, ...props }) {
           return <MarkdownCodeBlock {...props} style={style} />;

--- a/src/components/Reveal/reveal.module.css
+++ b/src/components/Reveal/reveal.module.css
@@ -8,6 +8,7 @@
 
 .reveal_hidden {
   width: 100%;
+  overflow: hidden;
   max-height: 9em;
   mask-image: linear-gradient(
     to bottom,


### PR DESCRIPTION
# Fix: ToolsContent overflow issue

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- Problem: `tree()` tool in collapsed state was not hiding content which overflows, which led to unexpectedly increased scroll height
- Solution: Hiding overflow for collapsible root element
- [ToolsContent are not hiding overflow inside, if tool content is collapsible](https://refact.fibery.io/Software_Development/UI-UX-133#Task/ToolsContent-are-not-hiding-overflow-inside,-if-tool-content-is-collapsible-342)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->

- Step 1: Ask in the chat to call tree
- Step 2: Expand tool content, then check scroll
- Step 3: Click on "Click for more" to expand collapsible, scroll should increase correctly

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.