### PR TITLE
Fix tip of the day double next

### DIFF
--- a/src/app/middleware.ts
+++ b/src/app/middleware.ts
@@ -129,13 +129,22 @@ startListening({
 });
 
 startListening({
-  matcher: isAnyOf(restoreChat, newChatAction),
-  effect: (_action, listenerApi) => {
+  matcher: isAnyOf(restoreChat, newChatAction, updateConfig),
+  effect: (action, listenerApi) => {
     const state = listenerApi.getState();
+    const isUpdate = updateConfig.match(action);
+
+    const host =
+      isUpdate && action.payload.host ? action.payload.host : state.config.host;
+
+    const completeManual = isUpdate
+      ? action.payload.keyBindings?.completeManual
+      : state.config.keyBindings?.completeManual;
+
     listenerApi.dispatch(
       nextTip({
-        host: state.config.host,
-        completeManual: state.config.keyBindings?.completeManual,
+        host,
+        completeManual,
       }),
     );
   },

--- a/src/app/middleware.ts
+++ b/src/app/middleware.ts
@@ -20,6 +20,7 @@ import { pingApi } from "../services/refact/ping";
 import { clearError, setError } from "../features/Errors/errorsSlice";
 import { updateConfig } from "../features/Config/configSlice";
 import { resetAttachedImagesSlice } from "../features/AttachedImages";
+import { nextTip } from "../features/TipOfTheDay";
 
 export const listenerMiddleware = createListenerMiddleware();
 const startListening = listenerMiddleware.startListening.withTypes<
@@ -124,5 +125,18 @@ startListening({
     if (action.payload.id === state.chat.thread.id) {
       listenerApi.dispatch(resetAttachedImagesSlice());
     }
+  },
+});
+
+startListening({
+  matcher: isAnyOf(restoreChat, newChatAction),
+  effect: (_action, listenerApi) => {
+    const state = listenerApi.getState();
+    listenerApi.dispatch(
+      nextTip({
+        host: state.config.host,
+        completeManual: state.config.keyBindings?.completeManual,
+      }),
+    );
   },
 });

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -23,7 +23,7 @@ import {
 import { smallCloudApi } from "../services/smallcloud";
 import { reducer as fimReducer } from "../features/FIM/reducer";
 import { tourReducer } from "../features/Tour";
-import { tipOfTheDayReducer } from "../features/TipOfTheDay";
+import { tipOfTheDaySlice } from "../features/TipOfTheDay";
 import { reducer as configReducer } from "../features/Config/configSlice";
 import { activeFileReducer } from "../features/Chat/activeFile";
 import { selectedSnippetReducer } from "../features/Chat/selectedSnippet";
@@ -48,8 +48,8 @@ const tipOfTheDayPersistConfig = {
 };
 
 const persistedTipOfTheDayReducer = persistReducer<
-  ReturnType<typeof tipOfTheDayReducer>
->(tipOfTheDayPersistConfig, tipOfTheDayReducer);
+  ReturnType<typeof tipOfTheDaySlice.reducer>
+>(tipOfTheDayPersistConfig, tipOfTheDaySlice.reducer);
 
 // https://redux-toolkit.js.org/api/combineSlices
 // `combineSlices` automatically combines the reducers using
@@ -58,7 +58,8 @@ const rootReducer = combineSlices(
   {
     fim: fimReducer,
     tour: tourReducer,
-    tipOfTheDay: persistedTipOfTheDayReducer,
+    // tipOfTheDay: persistedTipOfTheDayReducer,
+    [tipOfTheDaySlice.reducerPath]: persistedTipOfTheDayReducer,
     config: configReducer,
     active_file: activeFileReducer,
     selected_snippet: selectedSnippetReducer,

--- a/src/components/ChatContent/ChatContent.tsx
+++ b/src/components/ChatContent/ChatContent.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback } from "react";
 import {
   ChatMessages,
   isChatContextFileMessage,
@@ -16,9 +16,7 @@ import { AssistantInput } from "./AssistantInput";
 import { useAutoScroll } from "./useAutoScroll";
 import { PlainText } from "./PlainText";
 import { useConfig, useEventsBusForIDE } from "../../hooks";
-import { useAppSelector, useAppDispatch } from "../../hooks";
-import { RootState } from "../../app/store";
-import { next } from "../../features/TipOfTheDay";
+import { useAppSelector } from "../../hooks";
 import {
   selectIsStreaming,
   selectIsWaiting,
@@ -27,25 +25,18 @@ import {
 import { takeWhile } from "../../utils";
 import { GroupedDiffs } from "./DiffContent";
 import { ScrollToBottomButton } from "./ScrollToBottomButton";
+import { currentTipOfTheDay } from "../../features/TipOfTheDay";
 
-export const TipOfTheDay: React.FC = () => {
-  const dispatch = useAppDispatch();
-  const config = useConfig();
-  const state = useAppSelector((state: RootState) => state.tipOfTheDay);
-
-  // TODO: find out what this is about.
-  useEffect(() => {
-    dispatch(next(config));
-  }, [dispatch, config]);
+const TipOfTheDay: React.FC = () => {
+  const tip = useAppSelector(currentTipOfTheDay);
 
   return (
     <Text>
-      💡 <b>Tip of the day</b>: {state.tip}
+      💡 <b>Tip of the day</b>: {tip}
     </Text>
   );
 };
 
-// TODO: turn this into a component
 const PlaceHolderText: React.FC = () => {
   const config = useConfig();
   const hasVecDB = config.features?.vecdb ?? false;


### PR DESCRIPTION
# Tip of the day double next call


## Description

Next was being called when the Tip of the day component mounts, causing it to change it's children and remount.

The cases for incrementing the tip have been added to some middleware.

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

- Step 1: One a chat and redux dev tools,
- Step 2: Click "new chat"
- Step 3: tipoftheDay/next should only have been called once.

## Screenshots (if applicable)


## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.

## Linked Issues


- Fixes https://refact.fibery.io/Software_Development/UI-chat-js-133#Task/Tip-of-the-day-is-jumping-over-by-one-tip-each-time-we-are-starting-a-new-chat-341


## Additional Notes

