### PR TITLE
feat(already_applied): so info if patch is already applied.

### DIFF
--- a/src/services/refact/diffs.ts
+++ b/src/services/refact/diffs.ts
@@ -28,6 +28,7 @@ function isPatchState(json: unknown): json is PatchState {
 
 export type PatchResult = {
   file_text: string;
+  already_applied: boolean;
   file_name_edit: string | null;
   file_name_delete: string | null;
   file_name_add: string | null;
@@ -35,20 +36,31 @@ export type PatchResult = {
 
 function isPatchResult(json: unknown): json is PatchResult {
   if (!json || typeof json !== "object") return false;
+
   if (!("file_text" in json)) return false;
   if (typeof json.file_text !== "string") return false;
+
+  if (!("already_applied" in json)) return false;
+  if (typeof json.already_applied !== "boolean") return false;
+
   if (!("file_name_edit" in json)) return false;
-  if (typeof json.file_name_edit !== "string" && json.file_name_edit !== null)
+  if (typeof json.file_name_edit !== "string" && json.file_name_edit !== null) {
     return false;
+  }
+
   if (!("file_name_delete" in json)) return false;
   if (
     typeof json.file_name_delete !== "string" &&
     json.file_name_delete !== null
-  )
+  ) {
     return false;
+  }
+
   if (!("file_name_add" in json)) return false;
-  if (typeof json.file_name_add !== "string" && json.file_name_add !== null)
+  if (typeof json.file_name_add !== "string" && json.file_name_add !== null) {
     return false;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
# Show info when a patch is already applied

## Description

Update to diff api, it should be able to tell the user when the patch is already applied.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test


- Step 1: Build chat `npm run build`
- Step 2: create a link `npm link`
- Step 3: goto vscode project
- Step 4: `npm link refact-chat-js`
- Step 5: `npm run compile -- --watch`
- Step 6: start asking chat to make changes
- Step 7: click "auto apply" a few times.


## Screenshots (if applicable)

See video in ticket.

## Checklist


- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.

## Linked Issues

https://refact.fibery.io/Software_Development/UI-chat-js-133#Task/Pin-already-appied-381

## Additional Notes

There maybe some bugs in the lsp :/
