### PR TITLE
Fix/image size limit

### DIFF
--- a/src/components/Dropzone/Dropzone.tsx
+++ b/src/components/Dropzone/Dropzone.tsx
@@ -43,7 +43,17 @@ export const DropzoneProvider: React.FC<
     noClick: true,
     noKeyboard: true,
     accept: {
-      "image/*": [],
+      // "image/*": []
+      "image/apng": [],
+      "image/avif": [],
+      "image/gif": [],
+      "image/jpeg": [],
+      "image/png": [],
+      "image/svg+xml": [],
+      "image/webp": [],
+      "image/bmp": [],
+      "image/x-icon": [],
+      // "image/tiff": []
     },
     onDrop,
   });

--- a/src/components/Dropzone/Dropzone.tsx
+++ b/src/components/Dropzone/Dropzone.tsx
@@ -4,6 +4,7 @@ import { Cross1Icon, ImageIcon } from "@radix-ui/react-icons";
 import { DropzoneInputProps, FileRejection, useDropzone } from "react-dropzone";
 import { useAttachedImages } from "../../hooks/useAttachedImages";
 import { TruncateLeft } from "../Text";
+import { ImageFile } from "../../features/AttachedImages/imagesSlice";
 
 export const FileUploadContext = createContext<{
   open: () => void;
@@ -20,24 +21,8 @@ export const DropzoneProvider: React.FC<
   const { insertImage, setError, setWarning } = useAttachedImages();
 
   const onDrop = useCallback(
-    (acceptedFiles: File[], fileRejections: FileRejection[]) => {
-      acceptedFiles.forEach((file) => {
-        const reader = new FileReader();
-        reader.onabort = () =>
-          setWarning(`file ${file.name} reading was aborted`);
-
-        reader.onerror = () => setError(`file ${file.name} reading has failed`);
-
-        reader.onload = () => {
-          const fileForChat = {
-            name: file.name,
-            content: reader.result,
-            type: file.type,
-          };
-          insertImage(fileForChat);
-        };
-        reader.readAsDataURL(file);
-      });
+    (acceptedFiles: File[], fileRejections: FileRejection[]): void => {
+      void processImages(acceptedFiles, insertImage, setError, setWarning);
 
       if (fileRejections.length) {
         const rejectedFileMessage = fileRejections.map((file) => {
@@ -133,3 +118,68 @@ export const FileList = () => {
     </Flex>
   );
 };
+
+async function processImages(
+  files: File[],
+  onSuccess: (image: ImageFile) => void,
+  onError: (reason: string) => void,
+  onAbort: (reason: string) => void,
+) {
+  for (const file of files) {
+    try {
+      const scaledImage = await scaleImage(file, 800);
+      const fileForChat = {
+        name: file.name,
+        content: scaledImage,
+        type: file.type,
+      };
+
+      onSuccess(fileForChat);
+    } catch (error) {
+      if (error === "abort") {
+        onAbort(`file ${file.name} reading was aborted`);
+      } else {
+        onError(`file ${file.name} processing has failed`);
+      }
+    }
+  }
+}
+
+function scaleImage(file: File, maxSize: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        const canvas = document.createElement("canvas");
+        const ctx = canvas.getContext("2d");
+        if (ctx === null) {
+          reject(`canvas.getContext("2d"), returned null`);
+        }
+
+        let width = img.width;
+        let height = img.height;
+
+        if (width > height && width > maxSize) {
+          height = Math.round((height *= maxSize / width));
+          width = maxSize;
+        } else if (height >= width && height > maxSize) {
+          width = Math.round((width *= maxSize / height));
+          height = maxSize;
+        }
+
+        canvas.width = width;
+        canvas.height = height;
+        ctx?.drawImage(img, 0, 0, width, height);
+
+        resolve(canvas.toDataURL(file.type));
+      };
+      img.onerror = reject;
+      img.src = reader.result as string;
+    };
+
+    reader.onabort = () => reject("aborted");
+    reader.onerror = () => reject("error");
+    reader.readAsDataURL(file);
+  });
+}

--- a/src/components/Dropzone/Dropzone.tsx
+++ b/src/components/Dropzone/Dropzone.tsx
@@ -44,15 +44,15 @@ export const DropzoneProvider: React.FC<
     noKeyboard: true,
     accept: {
       // "image/*": []
-      "image/apng": [],
-      "image/avif": [],
-      "image/gif": [],
+      // "image/apng": [],
+      // "image/avif": [],
+      // "image/gif": [],
       "image/jpeg": [],
       "image/png": [],
-      "image/svg+xml": [],
-      "image/webp": [],
-      "image/bmp": [],
-      "image/x-icon": [],
+      // "image/svg+xml": [],
+      // "image/webp": [],
+      // "image/bmp": [],
+      // "image/x-icon": [],
       // "image/tiff": []
     },
     onDrop,


### PR DESCRIPTION
# Downscale large images

## Description

This PR will down scale user provided images to 800px.

Alternatively we could downscale by checking the size in bytes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test


- Step 1: Find a large image, (here's some https://svs.gsfc.nasa.gov/vis/a030000/a030800/a030877/frames/5760x3240_16x9_01p/)
- Step 2: Add the image to chat
- Step 3: it should still work

Note: vscode seems to have a limit on the payload size :/

## Screenshots (if applicable)



## Checklist


- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.

## Linked Issues

https://refact.fibery.io/Software_Development/UI-UX-133#Task/Chat-rendering-crashes-when-trying-to-load-a-large-image-409

## Additional Notes

I'll need to check a high=def image that is less than 800px
