### PR TITLE
Fix: Minimal width for tools execution output

### DIFF
--- a/src/components/Command/Command.module.css
+++ b/src/components/Command/Command.module.css
@@ -22,4 +22,5 @@
 
 .isInsideScrollArea {
   width: fit-content;
+  min-width: 100%;
 }


### PR DESCRIPTION
# Fix: Minimal width for tools execution output

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- Problem: Now, if the tool is returning as output small message, actual box of it will be not covering all available area.
- Solution: `min-width` set up

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->

- Step 1: Call `tree` tool in small project, it should now look better

## Screenshots (if applicable)

<!-- If your changes include UI modifications, attach relevant screenshots here. -->
### Before
![Before](https://github.com/user-attachments/assets/3fde402d-8199-4590-9f21-33a903415c59)
### After
![After](https://github.com/user-attachments/assets/d5fff09c-d0dd-45f1-b524-075327015430)


## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.