### PR TITLE
Fix: Tool Confirmation layout & styling

### DIFF
--- a/src/components/ChatForm/ToolConfirmation.module.css
+++ b/src/components/ChatForm/ToolConfirmation.module.css
@@ -1,11 +1,16 @@
 .ToolConfirmationCard {
+  position: absolute;
+  width: calc(100% - 80px);
+  bottom: 40px;
+  left: 50%;
+  transform: translateX(-50%);
+
   padding: 15px 20px;
   display: flex;
   flex-direction: column;
   gap: 8px;
   border-radius: 8px;
   background-color: var(--color-surface);
-  margin-top: 20px;
   min-height: fit-content;
   & pre {
     margin: 0;
@@ -22,7 +27,6 @@
   max-width: 100%;
   font-size: 15px;
   white-space: pre-wrap;
-  color: white;
 }
 
 .ToolConfirmationTool {


### PR DESCRIPTION
# Fix: Tool Confirmation layout & styling

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- Problem: layout of tool confirmation popup was shifted if confirmation was needed not on the first tool call, but later on in the chat with lots of messages present. In the light theme, text was not changed to black, it was white
- Solution: Adjusted styles of `ToolConfirmationCard`
- [Tool Confirmation: Layout shift & colors issue in light theme](https://refact.fibery.io/Software_Development/UI-UX-133#Task/Tool-Confirmation-Layout-shift-colors-issue-in-light-theme-434)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## Screenshots (if applicable)

<!-- If your changes include UI modifications, attach relevant screenshots here. -->

### Light theme
![Light theme](https://github.com/user-attachments/assets/0e8d40ba-fefc-42d9-8006-0b92de6480fc)

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.