### PR TITLE
fix(agent links): only show link when in agent mode, also set mode wh…

### DIFF
--- a/src/components/ChatLinks/ChatLinks.tsx
+++ b/src/components/ChatLinks/ChatLinks.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { Button } from "@radix-ui/themes";
 import { type ChatLink } from "../../services/refact/links";
-import { useLinksFromLsp } from "../../hooks";
+import { useAppSelector, useLinksFromLsp } from "../../hooks";
 import { Spinner } from "@radix-ui/themes";
 import { TruncateRight } from "../Text/TruncateRight";
+import { selectThreadToolUse } from "../../features/Chat";
 
 function maybeConcatActionAndGoToStrings(link: ChatLink): string | undefined {
   const hasAction = "action" in link;
@@ -16,8 +17,10 @@ function maybeConcatActionAndGoToStrings(link: ChatLink): string | undefined {
 
 export const ChatLinks: React.FC = () => {
   const { linksResult, handleLinkAction, streaming } = useLinksFromLsp();
+  const toolUse = useAppSelector(selectThreadToolUse);
 
   if (streaming) return null;
+  if (toolUse !== "agent") return null;
 
   // TODO: waiting, errors, maybe add a title
 

--- a/src/features/Chat/Thread/reducer.ts
+++ b/src/features/Chat/Thread/reducer.ts
@@ -73,7 +73,7 @@ export const chatReducer = createReducer(initialState, (builder) => {
   builder.addCase(setToolUse, (state, action) => {
     state.thread.tool_use = action.payload;
     state.tool_use = action.payload;
-    state.thread.mode = chatModeToLspMode(action.payload, state.thread.mode);
+    state.thread.mode = chatModeToLspMode(action.payload);
   });
 
   builder.addCase(setPreventSend, (state, action) => {

--- a/src/hooks/useLinksFromLsp.ts
+++ b/src/hooks/useLinksFromLsp.ts
@@ -18,7 +18,6 @@ import {
   selectMessages,
   selectModel,
   selectThreadMode,
-  selectThreadToolUse,
   setIntegrationData,
 } from "../features/Chat";
 import { useGoToLink } from "./useGoToLink";
@@ -41,7 +40,6 @@ export function useLinksFromLsp() {
   const chatId = useAppSelector(selectChatId);
   const maybeIntegration = useAppSelector(selectIntegration);
   const threadMode = useAppSelector(selectThreadMode);
-  const toolUse = useAppSelector(selectThreadToolUse);
 
   // TODO: add the model
   const caps = useGetCapsQuery();
@@ -160,19 +158,10 @@ export function useLinksFromLsp() {
       messages.length > 0 && isUserMessage(messages[messages.length - 1]);
     if (!model) return true;
     if (!caps.data) return true;
-    if (toolUse !== "agent") return true;
     return (
       isStreaming || isWaiting || unCalledTools || lastMessageIsUserMessage
     );
-  }, [
-    caps.data,
-    isStreaming,
-    isWaiting,
-    messages,
-    model,
-    toolUse,
-    unCalledTools,
-  ]);
+  }, [caps.data, isStreaming, isWaiting, messages, model, unCalledTools]);
 
   const linksResult = linksApi.useGetLinksForChatQuery(
     {

--- a/src/services/refact/links.ts
+++ b/src/services/refact/links.ts
@@ -3,6 +3,7 @@ import { RootState } from "../../app/store";
 import { ChatMessages } from "./types";
 import { formatMessagesForLsp } from "../../features/Chat/Thread/utils";
 import { CHAT_COMMIT_LINK_URL, CHAT_LINKS_URL } from "./consts";
+import { LspChatMode } from "../../features/Chat";
 
 // goto: can be an integration file to open in settings, a file to open in an idea or a global integration.
 // XXX rename to:
@@ -67,7 +68,7 @@ export type LinksApiRequest = {
   chat_id: string;
   messages: ChatMessages;
   model: string;
-  mode?: string;
+  mode?: LspChatMode;
   current_config_file?: string;
 };
 


### PR DESCRIPTION
# Fix show links on non agent setting.

## Description

Set the mode when setting tool use and hide links when not in agent.

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

- Step 1: Start a chat in agent mode, wait for links.
- Step 2: Switch to explore mode, no links should show.


## Screenshots (if applicable)


## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.

## Linked Issues


## Additional Notes

