### PR TITLE
fix(chat request): set is waiting to true before making the tools req…

### DIFF
--- a/src/features/Chat/Thread/actions.ts
+++ b/src/features/Chat/Thread/actions.ts
@@ -102,6 +102,10 @@ export const setIntegrationData = createAction<Partial<IntegrationMeta>>(
   "chatThread/setIntegrationData",
 );
 
+export const setIsWaitingForResponse = createAction<boolean>(
+  "chatThread/setIsWaiting",
+);
+
 // TODO: This is the circular dep when imported from hooks :/
 const createAppAsyncThunk = createAsyncThunk.withTypes<{
   state: RootState;

--- a/src/features/Chat/Thread/reducer.ts
+++ b/src/features/Chat/Thread/reducer.ts
@@ -27,6 +27,7 @@ import {
   setSendImmediately,
   setChatMode,
   setIntegrationData,
+  setIsWaitingForResponse,
 } from "./actions";
 import { formatChatResponse } from "./utils";
 
@@ -237,5 +238,9 @@ export const chatReducer = createReducer(initialState, (builder) => {
 
   builder.addCase(setIntegrationData, (state, action) => {
     state.thread.integration = action.payload;
+  });
+
+  builder.addCase(setIsWaitingForResponse, (state, action) => {
+    state.waiting_for_response = action.payload;
   });
 });

--- a/src/hooks/useSendChatRequest.ts
+++ b/src/hooks/useSendChatRequest.ts
@@ -40,7 +40,12 @@ import {
   getToolsConfirmationStatus,
   setPauseReasons,
 } from "../features/ToolConfirmation/confirmationSlice";
-import { chatModeToLspMode, LspChatMode, setChatMode } from "../features/Chat";
+import {
+  chatModeToLspMode,
+  LspChatMode,
+  setChatMode,
+  setIsWaitingForResponse,
+} from "../features/Chat";
 
 let recallCounter = 0;
 
@@ -78,6 +83,8 @@ export const useSendChatRequest = () => {
 
   const sendMessages = useCallback(
     async (messages: ChatMessages, maybeMode?: LspChatMode) => {
+      dispatch(setIsWaitingForResponse(true));
+
       let tools = await triggerGetTools(undefined).unwrap();
       // TODO: save tool use to state.chat
       // if (toolUse && isToolUse(toolUse)) {


### PR DESCRIPTION
# Spinner when waiting for tools

## Description

Sometimes when submitting a chat the tools request takes a while to resolve and no spinner is shown to the user.

This PR sets `waiting_for_response` before the tools request is sent.


## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test


- Step 1: Send a chat
- Step 2: A spinner should show up before the request to `/tools` resolves.


## Screenshots (if applicable)

<!-- If your changes include UI modifications, attach relevant screenshots here. -->


## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.

## Linked Issues



## Additional Notes

