### PR TITLE
feat(lsp port): allow setting the lsp port during dev.

### DIFF
--- a/src/features/Config/configSlice.ts
+++ b/src/features/Config/configSlice.ts
@@ -27,7 +27,7 @@ export type Config = {
 
 const initialState: Config = {
   host: "web",
-  lspPort: 8001,
+  lspPort: window.__REFACT_LSP_PORT__ ?? 8001,
   apiKey: null,
   features: {
     statistics: true,

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_REFACT_LSP_URL?: string;
+  readonly VITE_REFACT_LSP_PORT?: string;
 }
 interface ImportMeta {
   readonly env: ImportMetaEnv;
@@ -12,4 +12,5 @@ declare const __REFACT_CHAT_VERSION__: VersionInfo;
 
 interface Window {
   __REFACT_CHAT_VERSION__: VersionInfo;
+  __REFACT_LSP_PORT__?: number;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,9 @@ function makeConfig(library: "browser" | "node") {
           commit: commitHash,
         }),
         "process.env.DEBUG": JSON.stringify(process.env.DEBUG),
+        ...(process.env.REFACT_LSP_PORT
+          ? { __REFACT_LSP_PORT__: process.env.REFACT_LSP_PORT }
+          : {}),
       },
       mode,
       build: {


### PR DESCRIPTION
# Set lsp port


## Description

During dev the user may want to change the lsp port.



## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test


- Step 1: run chat in dev with `REFACT_LSP_PORT="9001" npm run dev`
- Step 2: request to the lsp should use port 9001.

## Screenshots (if applicable)

<!-- If your changes include UI modifications, attach relevant screenshots here. -->



## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.

## Linked Issues



## Additional Notes

