### PR TITLE
Fix: Confirmation rules proper rendering

### DIFF
--- a/src/components/IntegrationsView/IntegrationForm/IntegrationForm.tsx
+++ b/src/components/IntegrationsView/IntegrationForm/IntegrationForm.tsx
@@ -269,8 +269,8 @@ export const IntegrationForm: FC<IntegrationFormProps> = ({
                         integration.data.integr_values.confirmation,
                         confirmationRules,
                       )
-                        ? integration.data.integr_values.confirmation
-                        : confirmationRules
+                        ? confirmationRules
+                        : integration.data.integr_values.confirmation
                     }
                     onChange={handleConfirmationChange}
                   />

--- a/src/components/IntegrationsView/IntegrationsView.tsx
+++ b/src/components/IntegrationsView/IntegrationsView.tsx
@@ -93,16 +93,17 @@ export const IntegrationsView: FC<IntegrationViewProps> = ({
   const maybeIntegration = useMemo(() => {
     if (!currentThreadIntegration) return null;
     if (!integrationsMap) return null;
+    const integrationName = currentThreadIntegration.integrationName;
+    const isCmdline = integrationName?.startsWith("cmdline");
+    const isService = integrationName?.startsWith("service");
+
     // TODO: check for extra flag in currentThreadIntegration to return different find() call from notConfiguredGrouped integrations if it's set to true
     const integration =
-      integrationsMap.integrations.find(
-        (integration) =>
-          currentThreadIntegration.integrationName?.startsWith("cmdline")
-            ? integration.integr_name === "cmdline_TEMPLATE"
-            : integration.integr_name ===
-              currentThreadIntegration.integrationName,
-        // integration.integr_name === currentThreadIntegration.integrationName,
-      ) ?? null;
+      integrationsMap.integrations.find((integration) => {
+        if (isCmdline) return integration.integr_name === "cmdline_TEMPLATE";
+        if (isService) return integration.integr_name === "service_TEMPLATE";
+        return integration.integr_name === integrationName;
+      }) ?? null;
     if (!integration) return null;
 
     const integrationWithFlag = {


### PR DESCRIPTION
# Fix: Confirmation rules proper rendering

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- Problem: after comparing `confirmationRules` and rules from `integr_values`, I was rendering local `confirmationRules`, if rules are different and remote ones, if rules are the same.
- Solution: adjusted ternary expression.
- [🔴 Integration page - deny and confirm editor](https://refact.fibery.io/Software_Development/Current-Week-by-state-358#Task/Integration-page---deny-and-confirm-editor-537)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->

- Step 1: Open any integration, edit confirmation rules and save
- Step 2: Reopen integration
- Step 3: Rules should be rendered from the LSP's output

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.