### PR TITLE
UI fixes links and commit warning

### DIFF
--- a/src/components/Buttons/Buttons.tsx
+++ b/src/components/Buttons/Buttons.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { IconButton, Button, Flex } from "@radix-ui/themes";
 import {
   PaperPlaneIcon,
@@ -8,6 +8,7 @@ import {
 } from "@radix-ui/react-icons";
 import classNames from "classnames";
 import styles from "./button.module.css";
+import { useOpenUrl } from "../../hooks/useOpenUrl";
 
 type IconButtonProps = React.ComponentProps<typeof IconButton>;
 type ButtonProps = React.ComponentProps<typeof Button>;
@@ -72,8 +73,13 @@ export const LinkButton: React.FC<
     onClick?: () => void;
   }
 > = ({ href, target, onClick, ...rest }) => {
+  const openUrl = useOpenUrl();
+  const handleClick = useCallback(() => {
+    if (onClick) onClick();
+    if (href) openUrl(href);
+  }, [href, onClick, openUrl]);
   return (
-    <form action={href} target={target} onSubmit={onClick}>
+    <form action={href} target={target} onSubmit={handleClick}>
       <Button type="submit" {...rest}>
         Upgrade to our pro plan
       </Button>

--- a/src/components/ChatLinks/UncommittedChangesWarning.tsx
+++ b/src/components/ChatLinks/UncommittedChangesWarning.tsx
@@ -9,8 +9,15 @@ export const UncommittedChangesWarning: React.FC = () => {
   const isWaiting = useAppSelector(selectIsWaiting);
   const linksRequest = useGetLinksFromLsp();
 
-  if (isStreaming || isWaiting) return false;
-  if (!linksRequest.data?.uncommited_changes_warning) return false;
+  if (
+    isStreaming ||
+    isWaiting ||
+    linksRequest.isFetching ||
+    linksRequest.isLoading ||
+    !linksRequest.data?.uncommited_changes_warning
+  ) {
+    return false;
+  }
 
   return (
     <Flex py="4" gap="4" direction="column" justify="between">

--- a/src/components/ChatLinks/UncommittedChangesWarning.tsx
+++ b/src/components/ChatLinks/UncommittedChangesWarning.tsx
@@ -1,11 +1,15 @@
 import React from "react";
-import { useGetLinksFromLsp } from "../../hooks";
+import { useAppSelector, useGetLinksFromLsp } from "../../hooks";
 import { Markdown } from "../Markdown";
 import { Flex, Separator } from "@radix-ui/themes";
+import { selectIsStreaming, selectIsWaiting } from "../../features/Chat";
 
 export const UncommittedChangesWarning: React.FC = () => {
+  const isStreaming = useAppSelector(selectIsStreaming);
+  const isWaiting = useAppSelector(selectIsWaiting);
   const linksRequest = useGetLinksFromLsp();
 
+  if (isStreaming || isWaiting) return false;
   if (!linksRequest.data?.uncommited_changes_warning) return false;
 
   return (


### PR DESCRIPTION
# Pro links an commit warning fixes

## Description

When running in an ide, the `upgrade to pro` button didn't work.
the `useOpenUrl` hook has been reused so the ide opens the url.

Commit warning message stayed on screen while chat was streaming, this has been removed.

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->

- Step 1: Build chat and run it in an ide.
- Step 2: Logout ad back in as a free user
- Step 3: Send about 15 to 20 messages.
- Step 4: There should be a warning about usage limits.
- Step 5: click the upgrade button
- Step 6: the ide should open to refacts upgrade page.

Step: 7 open a project with uncommitted changes.
Step 8: There should be a warning.
Step 9: send a message
Step 10: the warning should disappear while the chat is streaming. 

## Screenshots (if applicable)



## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.

## Linked Issues

<!-- List any related issues that this pull request addresses. Use "Fixes #" or "Closes #" to link the PR to specific issues. -->

https://refact.fibery.io/Software_Development/Release-6.1-433#Task/Uncommitted-warning----remains-on-screen-even-when-the-streaming-started-592



## Additional Notes

