### PR TITLE
Fix/UI jumps

### DIFF
--- a/src/app/middleware.ts
+++ b/src/app/middleware.ts
@@ -43,10 +43,10 @@ startListening({
   ),
   effect: (_action, listenerApi) => {
     [
-      pingApi.util.resetApiState(),
+      // pingApi.util.resetApiState(),
       statisticsApi.util.resetApiState(),
-      capsApi.util.resetApiState(),
-      promptsApi.util.resetApiState(),
+      // capsApi.util.resetApiState(),
+      // promptsApi.util.resetApiState(),
       toolsApi.util.resetApiState(),
       commandsApi.util.resetApiState(),
       diffApi.util.resetApiState(),

--- a/src/components/Chat/Chat.stories.tsx
+++ b/src/components/Chat/Chat.stories.tsx
@@ -15,6 +15,7 @@ import {
   goodUser,
   chatLinks,
   goodTools,
+  noTools,
 } from "../../__fixtures__/msw";
 import { TourProvider } from "../../features/Tour";
 import { Flex } from "@radix-ui/themes";
@@ -95,14 +96,6 @@ export const Configuration: Story = {
   args: {
     thread: CHAT_CONFIG_THREAD.thread,
   },
-
-  //   parameters: {
-  //     parameters: {
-  //       msw: {
-  //         handlers: [goodCaps, goodPing, goodPrompts, goodUser, chatLinks],
-  //       },
-  //     },
-  //   },
 };
 
 export const IDE: Story = {
@@ -111,6 +104,13 @@ export const IDE: Story = {
       host: "ide",
       lspPort: 8001,
       themeProps: {},
+      features: { vecdb: true },
+    },
+  },
+
+  parameters: {
+    msw: {
+      handlers: [goodCaps, goodPing, goodPrompts, goodUser, chatLinks, noTools],
     },
   },
 };

--- a/src/components/Chat/Chat.stories.tsx
+++ b/src/components/Chat/Chat.stories.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { Chat } from "./Chat";
 import { ChatThread } from "../../features/Chat/Thread/types";
-import { setUpStore } from "../../app/store";
+import { RootState, setUpStore } from "../../app/store";
 import { Provider } from "react-redux";
 import { Theme } from "../Theme";
 import { AbortControllerProvider } from "../../contexts/AbortControllers";
@@ -21,7 +21,8 @@ import { Flex } from "@radix-ui/themes";
 
 const Template: React.FC<{
   thread?: ChatThread;
-}> = ({ thread }) => {
+  config?: RootState["config"];
+}> = ({ thread, config }) => {
   const threadData = thread ?? {
     id: "test",
     model: "gpt-4o", // or any model from STUB CAPS REQUEst
@@ -42,6 +43,7 @@ const Template: React.FC<{
       system_prompt: {},
       thread: threadData,
     },
+    config,
   });
 
   return (
@@ -101,4 +103,14 @@ export const Configuration: Story = {
   //       },
   //     },
   //   },
+};
+
+export const IDE: Story = {
+  args: {
+    config: {
+      host: "ide",
+      lspPort: 8001,
+      themeProps: {},
+    },
+  },
 };

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -6,7 +6,6 @@ import {
   useAppSelector,
   useAppDispatch,
   useSendChatRequest,
-  useGetPromptsQuery,
   useAutoSend,
   useGetCapsQuery,
   useCapsForToolUse,
@@ -20,13 +19,10 @@ import {
   selectChatId,
   selectMessages,
   getSelectedToolUse,
-  getSelectedSystemPrompt,
-  setSystemPrompt,
 } from "../../features/Chat/Thread";
 import { ThreadHistoryButton } from "../Buttons";
 import { push } from "../../features/Pages/pagesSlice";
 import { DropzoneProvider } from "../Dropzone";
-import { SystemPrompts } from "../../services/refact";
 import { AgentUsage } from "../../features/AgentUsage";
 
 export type ChatProps = {
@@ -57,10 +53,6 @@ export const Chat: React.FC<ChatProps> = ({
   const messages = useAppSelector(selectMessages);
   const capsForToolUse = useCapsForToolUse();
 
-  const promptsRequest = useGetPromptsQuery();
-  const selectedSystemPrompt = useAppSelector(getSelectedSystemPrompt);
-  const onSetSelectedSystemPrompt = (prompt: SystemPrompts) =>
-    dispatch(setSystemPrompt(prompt));
   const [isDebugChatHistoryVisible, setIsDebugChatHistoryVisible] =
     useState(false);
 
@@ -131,12 +123,10 @@ export const Chat: React.FC<ChatProps> = ({
           key={chatId} // TODO: think of how can we not trigger re-render on chatId change (checkboxes)
           chatId={chatId}
           isStreaming={isStreaming}
+          // TODO: move this
           showControls={messages.length === 0 && !isStreaming}
           onSubmit={handleSummit}
           onClose={maybeSendToSidebar}
-          prompts={promptsRequest.data ?? {}}
-          onSetSystemPrompt={onSetSelectedSystemPrompt}
-          selectedSystemPrompt={selectedSystemPrompt}
           onToolConfirm={confirmToolUsage}
         />
 

--- a/src/components/ChatForm/ChatControls.tsx
+++ b/src/components/ChatForm/ChatControls.tsx
@@ -31,7 +31,7 @@ const CapsSelect: React.FC = () => {
       style={{ alignSelf: "flex-start" }}
     >
       <Text size="2">Use model:</Text>
-      <Skeleton loading={caps.loading || !caps.data}>
+      <Skeleton loading={caps.loading}>
         <Box minWidth="50px">
           {allDisabled ? (
             <Text size="1" color="gray">
@@ -39,7 +39,6 @@ const CapsSelect: React.FC = () => {
             </Text>
           ) : (
             <Select
-              disabled={caps.loading}
               title="chat model"
               options={caps.usableModelsForPlan}
               value={caps.currentModel}

--- a/src/components/ChatForm/ChatControls.tsx
+++ b/src/components/ChatForm/ChatControls.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { Text, Flex, HoverCard, Link } from "@radix-ui/themes";
+import { Text, Flex, HoverCard, Link, Skeleton } from "@radix-ui/themes";
 import { Select } from "../Select";
 import { type Config } from "../../features/Config/configSlice";
 import { TruncateLeft } from "../Text";
@@ -37,20 +37,21 @@ const CapsSelect: React.FC = () => {
     >
       {/** TODO: loading state */}
       <Text size="2">Use model:</Text>
-
-      {!caps.loading && allDisabled ? (
-        <Text size="1" color="gray">
-          No models available
-        </Text>
-      ) : (
-        <Select
-          disabled={caps.loading}
-          title="chat model"
-          options={caps.usableModelsForPlan}
-          value={caps.currentModel}
-          onChange={caps.setCapModel}
-        ></Select>
-      )}
+      <Skeleton loading={caps.loading}>
+        {allDisabled ? (
+          <Text size="1" color="gray">
+            No models available
+          </Text>
+        ) : (
+          <Select
+            disabled={caps.loading}
+            title="chat model"
+            options={caps.usableModelsForPlan}
+            value={caps.currentModel}
+            onChange={caps.setCapModel}
+          ></Select>
+        )}
+      </Skeleton>
     </Flex>
   );
 };

--- a/src/components/ChatForm/ChatControls.tsx
+++ b/src/components/ChatForm/ChatControls.tsx
@@ -27,12 +27,14 @@ const CapsSelect: React.FC = () => {
       gap="2"
       align="center"
       wrap="wrap"
+      flexGrow="1"
+      flexShrink="0"
+      width="100%"
       ref={(x) => refs.setUseModel(x)}
-      style={{ alignSelf: "flex-start" }}
     >
       <Text size="2">Use model:</Text>
       <Skeleton loading={caps.loading}>
-        <Box minWidth="50px">
+        <Box>
           {allDisabled ? (
             <Text size="1" color="gray">
               No models available
@@ -164,6 +166,7 @@ export const ChatControls: React.FC<ChatControlsProps> = ({
       pb="2"
       gap="2"
       direction="column"
+      align="start"
       className={classNames(styles.controls)}
     >
       {Object.entries(checkboxes).map(([key, checkbox]) => {
@@ -174,47 +177,33 @@ export const ChatControls: React.FC<ChatControlsProps> = ({
           return null;
         }
         return (
-          <Flex
-            style={{
-              // TODO: lots of `align` self
-              alignSelf: "flex-start",
-            }}
+          <ChatControlCheckBox
             key={key}
-          >
-            <ChatControlCheckBox
-              name={checkbox.name}
-              label={checkbox.label}
-              checked={checkbox.checked}
-              disabled={checkbox.disabled}
-              onCheckChange={(value) => onCheckedChange(key, value)}
-              infoText={checkbox.info?.text}
-              href={checkbox.info?.link}
-              linkText={checkbox.info?.linkText}
-              fileName={checkbox.fileName}
-            />
-          </Flex>
+            name={checkbox.name}
+            label={checkbox.label}
+            checked={checkbox.checked}
+            disabled={checkbox.disabled}
+            onCheckChange={(value) => onCheckedChange(key, value)}
+            infoText={checkbox.info?.text}
+            href={checkbox.info?.link}
+            linkText={checkbox.info?.linkText}
+            fileName={checkbox.fileName}
+          />
         );
       })}
 
       {showControls && (
-        <Flex
+        <ToolUseSwitch
           ref={(x) => refs.setUseTools(x)}
-          style={{ alignSelf: "flex-start" }}
-        >
-          <ToolUseSwitch toolUse={toolUse} setToolUse={onSetToolUse} />
-        </Flex>
+          toolUse={toolUse}
+          setToolUse={onSetToolUse}
+        />
       )}
 
-      {showControls && (
-        <Flex style={{ alignSelf: "flex-start" }}>
-          <CapsSelect />
-        </Flex>
-      )}
-      {showControls && (
-        <Flex style={{ alignSelf: "flex-start" }}>
-          <PromptSelect />
-        </Flex>
-      )}
+      <Flex gap="2" direction="column">
+        {showControls && <CapsSelect />}
+        {showControls && <PromptSelect />}
+      </Flex>
     </Flex>
   );
 };

--- a/src/components/ChatForm/ChatControls.tsx
+++ b/src/components/ChatForm/ChatControls.tsx
@@ -1,22 +1,17 @@
 import React, { useCallback } from "react";
-import { Text, Flex, HoverCard, Link, Skeleton } from "@radix-ui/themes";
+import { Text, Flex, HoverCard, Link, Skeleton, Box } from "@radix-ui/themes";
 import { Select } from "../Select";
 import { type Config } from "../../features/Config/configSlice";
 import { TruncateLeft } from "../Text";
 import styles from "./ChatForm.module.css";
 import classNames from "classnames";
-import { PromptSelect, PromptSelectProps } from "./PromptSelect";
+import { PromptSelect } from "./PromptSelect";
 import { Checkbox } from "../Checkbox";
 import { QuestionMarkCircledIcon } from "@radix-ui/react-icons";
 import { useTourRefs } from "../../features/Tour";
 import { ToolUseSwitch } from "./ToolUseSwitch";
 import { ToolUse, selectToolUse, setToolUse } from "../../features/Chat/Thread";
-import {
-  useAppSelector,
-  useAppDispatch,
-  useCapsForToolUse,
-  useCanUseTools,
-} from "../../hooks";
+import { useAppSelector, useAppDispatch, useCapsForToolUse } from "../../hooks";
 
 const CapsSelect: React.FC = () => {
   const refs = useTourRefs();
@@ -35,22 +30,23 @@ const CapsSelect: React.FC = () => {
       ref={(x) => refs.setUseModel(x)}
       style={{ alignSelf: "flex-start" }}
     >
-      {/** TODO: loading state */}
       <Text size="2">Use model:</Text>
       <Skeleton loading={caps.loading}>
-        {allDisabled ? (
-          <Text size="1" color="gray">
-            No models available
-          </Text>
-        ) : (
-          <Select
-            disabled={caps.loading}
-            title="chat model"
-            options={caps.usableModelsForPlan}
-            value={caps.currentModel}
-            onChange={caps.setCapModel}
-          ></Select>
-        )}
+        <Box minWidth="50px">
+          {allDisabled ? (
+            <Text size="1" color="gray">
+              No models available
+            </Text>
+          ) : (
+            <Select
+              disabled={caps.loading}
+              title="chat model"
+              options={caps.usableModelsForPlan}
+              value={caps.currentModel}
+              onChange={caps.setCapModel}
+            />
+          )}
+        </Box>
       </Skeleton>
     </Flex>
   );
@@ -79,7 +75,7 @@ export type ChatControlsProps = {
     name: keyof ChatControlsProps["checkboxes"],
     checked: boolean | string,
   ) => void;
-  promptsProps: PromptSelectProps;
+
   host: Config["host"];
   showControls: boolean;
 };
@@ -152,12 +148,10 @@ const ChatControlCheckBox: React.FC<{
 export const ChatControls: React.FC<ChatControlsProps> = ({
   checkboxes,
   onCheckedChange,
-  promptsProps,
   host,
   showControls,
 }) => {
   const refs = useTourRefs();
-  const canUseTools = useCanUseTools();
   const dispatch = useAppDispatch();
   const toolUse = useAppSelector(selectToolUse);
   const onSetToolUse = useCallback(
@@ -203,7 +197,7 @@ export const ChatControls: React.FC<ChatControlsProps> = ({
         );
       })}
 
-      {canUseTools && showControls && (
+      {showControls && (
         <Flex
           ref={(x) => refs.setUseTools(x)}
           style={{ alignSelf: "flex-start" }}
@@ -219,7 +213,7 @@ export const ChatControls: React.FC<ChatControlsProps> = ({
       )}
       {showControls && (
         <Flex style={{ alignSelf: "flex-start" }}>
-          <PromptSelect {...promptsProps} />
+          <PromptSelect />
         </Flex>
       )}
     </Flex>

--- a/src/components/ChatForm/ChatControls.tsx
+++ b/src/components/ChatForm/ChatControls.tsx
@@ -31,7 +31,7 @@ const CapsSelect: React.FC = () => {
       style={{ alignSelf: "flex-start" }}
     >
       <Text size="2">Use model:</Text>
-      <Skeleton loading={caps.loading}>
+      <Skeleton loading={caps.loading || !caps.data}>
         <Box minWidth="50px">
           {allDisabled ? (
             <Text size="1" color="gray">

--- a/src/components/ChatForm/ChatForm.stories.tsx
+++ b/src/components/ChatForm/ChatForm.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { ChatForm } from "./ChatForm";
-import { SYSTEM_PROMPTS } from "../../__fixtures__";
 import { useDebounceCallback } from "usehooks-ts";
 
 // const _testCommands = [
@@ -42,7 +41,7 @@ import { useDebounceCallback } from "usehooks-ts";
 //   "@Zucchini",
 // ];
 
-const noop = () => ({});
+// const noop = () => ({});
 
 const meta: Meta<typeof ChatForm> = {
   title: "Chat Form",
@@ -58,8 +57,6 @@ const meta: Meta<typeof ChatForm> = {
     },
     isStreaming: false,
     showControls: true,
-    prompts: SYSTEM_PROMPTS,
-    onSetSystemPrompt: noop,
   },
   decorators: [
     (Children) => {

--- a/src/components/ChatForm/ChatForm.test.tsx
+++ b/src/components/ChatForm/ChatForm.test.tsx
@@ -2,7 +2,6 @@ import { render } from "../../utils/test-utils";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ChatForm, ChatFormProps } from "./ChatForm";
 import React from "react";
-import { SYSTEM_PROMPTS } from "../../__fixtures__";
 
 import {
   server,
@@ -33,10 +32,7 @@ const App: React.FC<Partial<ChatFormProps>> = ({ ...props }) => {
     onSubmit: (_str: string) => ({}),
     isStreaming: false,
     showControls: true,
-    prompts: SYSTEM_PROMPTS,
-    onSetSystemPrompt: noop,
     onToolConfirm: noop,
-    selectedSystemPrompt: {},
     ...props,
   };
 

--- a/src/components/ChatForm/ChatForm.test.tsx
+++ b/src/components/ChatForm/ChatForm.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "../../utils/test-utils";
+import { render, fireEvent } from "../../utils/test-utils";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ChatForm, ChatFormProps } from "./ChatForm";
 import React from "react";
@@ -73,22 +73,26 @@ describe("ChatForm", () => {
     expect(fakeOnSubmit).not.toHaveBeenCalled();
   });
 
-  test("checkbox workspace", async () => {
-    const fakeOnSubmit = vi.fn();
-    const { user, ...app } = render(<App onSubmit={fakeOnSubmit} />);
+  test(
+    "checkbox workspace",
+    async () => {
+      const fakeOnSubmit = vi.fn();
+      const { user, ...app } = render(<App onSubmit={fakeOnSubmit} />);
 
-    const label = app.queryByText("Search workspace");
-    expect(label).not.toBeNull();
-    const btn = label?.querySelector("button");
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await user.click(btn!);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const textarea = app.container.querySelector("textarea")!;
-    await user.type(textarea, "foo");
-    await user.keyboard("{Enter}");
-    const expected = "@workspace\nfoo\n";
-    expect(fakeOnSubmit).toHaveBeenCalledWith(expected);
-  });
+      const btn = app.getByRole("checkbox", { name: /search workspace/i });
+
+      fireEvent.click(btn);
+      // screen.logTestingPlaygroundURL(app.container);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const textarea = app.container.querySelector("textarea")!;
+      await user.type(textarea, "foo");
+      await user.keyboard("{Enter}");
+      // app.debug(app.container, Infinity);
+      const expected = "@workspace\nfoo\n";
+      expect(fakeOnSubmit).toHaveBeenCalledWith(expected);
+    },
+    { retry: 0 },
+  );
 
   test.skip("checkbox lookup symbols", async () => {
     const fakeOnSubmit = vi.fn();

--- a/src/components/ChatForm/ChatForm.test.tsx
+++ b/src/components/ChatForm/ChatForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent } from "../../utils/test-utils";
+import { render } from "../../utils/test-utils";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ChatForm, ChatFormProps } from "./ChatForm";
 import React from "react";
@@ -71,56 +71,6 @@ describe("ChatForm", () => {
       await user.type(textarea, "{Shift>}{enter}{/Shift}");
     }
     expect(fakeOnSubmit).not.toHaveBeenCalled();
-  });
-
-  test(
-    "checkbox workspace",
-    async () => {
-      const fakeOnSubmit = vi.fn();
-      const { user, ...app } = render(<App onSubmit={fakeOnSubmit} />);
-
-      const btn = app.getByRole("checkbox", { name: /search workspace/i });
-
-      fireEvent.click(btn);
-      // screen.logTestingPlaygroundURL(app.container);
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const textarea = app.container.querySelector("textarea")!;
-      await user.type(textarea, "foo");
-      await user.keyboard("{Enter}");
-      // app.debug(app.container, Infinity);
-      const expected = "@workspace\nfoo\n";
-      expect(fakeOnSubmit).toHaveBeenCalledWith(expected);
-    },
-    { retry: 0 },
-  );
-
-  test.skip("checkbox lookup symbols", async () => {
-    const fakeOnSubmit = vi.fn();
-    const activeFile = {
-      name: "foo.txt",
-      line1: 1,
-      line2: 2,
-      can_paste: false,
-      attach: false,
-      path: "path/to/foo.txt",
-      cursor: 2,
-    };
-    const { user, ...app } = render(<App onSubmit={fakeOnSubmit} />, {
-      preloadedState: { active_file: activeFile },
-    });
-
-    const label = app.queryByText(/Lookup symbols/);
-    expect(label).not.toBeNull();
-    const btn = label?.querySelector("button");
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await user.click(btn!);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const textarea = app.container.querySelector("textarea")!;
-    await user.type(textarea, "foo");
-    await user.keyboard("{Enter}");
-    const expected = `@file ${activeFile.path}:${activeFile.line1}-${activeFile.line2}\n@symbols-at ${activeFile.path}:${activeFile.cursor}\nfoo\n`;
-
-    expect(fakeOnSubmit).toHaveBeenCalledWith(expected);
   });
 
   test("checkbox snippet", async () => {

--- a/src/components/ChatForm/ChatForm.tsx
+++ b/src/components/ChatForm/ChatForm.tsx
@@ -14,7 +14,6 @@ import {
 } from "../../hooks";
 import { ErrorCallout, Callout } from "../Callout";
 import { ComboBox } from "../ComboBox";
-import { SystemPrompts } from "../../services/refact";
 import { FilesPreview } from "./FilesPreview";
 import { ChatControls } from "./ChatControls";
 import { addCheckboxValuesToInput } from "./utils";
@@ -40,11 +39,7 @@ export type ChatFormProps = {
   onClose?: () => void;
   className?: string;
   isStreaming: boolean;
-
   showControls: boolean;
-  prompts: SystemPrompts;
-  onSetSystemPrompt: (prompt: SystemPrompts) => void;
-  selectedSystemPrompt: SystemPrompts;
   chatId: string;
   onToolConfirm: () => void;
 };
@@ -55,9 +50,6 @@ export const ChatForm: React.FC<ChatFormProps> = ({
   className,
   isStreaming,
   showControls,
-  prompts,
-  onSetSystemPrompt,
-  selectedSystemPrompt,
   onToolConfirm,
 }) => {
   const dispatch = useAppDispatch();
@@ -307,11 +299,6 @@ export const ChatForm: React.FC<ChatFormProps> = ({
         checkboxes={checkboxes}
         showControls={showControls}
         onCheckedChange={onToggleCheckbox}
-        promptsProps={{
-          value: selectedSystemPrompt,
-          prompts: prompts,
-          onChange: onSetSystemPrompt,
-        }}
       />
     </Card>
   );

--- a/src/components/ChatForm/PromptSelect.tsx
+++ b/src/components/ChatForm/PromptSelect.tsx
@@ -49,13 +49,15 @@ export const PromptSelect: React.FC = () => {
       gap="2"
       align="center"
       wrap="wrap"
-      style={{ alignSelf: "flex-start" }}
+      flexGrow="1"
+      flexShrink="0"
+      width="100%"
     >
       <Text size="2" wrap="nowrap">
         System Prompt:
       </Text>
       <Skeleton loading={promptsRequest.isLoading || promptsRequest.isFetching}>
-        <Box minWidth="80px">
+        <Box flexGrow="1" flexShrink="0">
           <Select
             name="system prompt"
             disabled={promptsRequest.isLoading}

--- a/src/components/ChatForm/ToolUseSwitch.tsx
+++ b/src/components/ChatForm/ToolUseSwitch.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Flex, SegmentedControl, Text, HoverCard } from "@radix-ui/themes";
 import { ToolUse } from "../../features/Chat/Thread";
 import { QuestionMarkCircledIcon } from "@radix-ui/react-icons";
@@ -7,9 +8,12 @@ type ToolUseSwitchProps = {
   setToolUse: (toolUse: ToolUse) => void;
 };
 
-export const ToolUseSwitch = ({ toolUse, setToolUse }: ToolUseSwitchProps) => {
+export const ToolUseSwitch = React.forwardRef<
+  HTMLDivElement,
+  ToolUseSwitchProps
+>(({ toolUse, setToolUse }, ref) => {
   return (
-    <Flex direction="column" gap="3" mb="2" align="start">
+    <Flex direction="column" gap="3" mb="2" align="start" ref={ref}>
       <Text size="2">How fast do you want the answer:</Text>
       <Flex direction="row" gap="1" align="center">
         <SegmentedControl.Root
@@ -54,4 +58,6 @@ export const ToolUseSwitch = ({ toolUse, setToolUse }: ToolUseSwitchProps) => {
       </Flex>
     </Flex>
   );
-};
+});
+
+ToolUseSwitch.displayName = "ToolUseSwitch";

--- a/src/components/ChatForm/useCheckBoxes.ts
+++ b/src/components/ChatForm/useCheckBoxes.ts
@@ -163,15 +163,19 @@ const useAttachSelectedSnippet = (
 
 const useSearchWorkSpace = (): [Checkbox, () => void] => {
   const vecdb = useAppSelector(selectVecdb);
-  const canUseTools = useCanUseTools();
+  const { canUseTools, loading } = useCanUseTools();
   const shouldShow = useAppSelector(shouldShowSelector);
+
+  const shouldHide = useMemo(() => {
+    return !vecdb || !shouldShow || loading || canUseTools;
+  }, [canUseTools, loading, shouldShow, vecdb]);
 
   const [searchWorkspace, setSearchWorkspace] = useState<Checkbox>({
     name: "search_workspace",
     checked: false,
     label: "Search workspace",
     disabled: false,
-    hide: !vecdb || !shouldShow || canUseTools,
+    hide: shouldHide,
     info: {
       text: "Searches all files in your workspace using vector database, uses the whole text in the input box as a search query. Setting this checkbox is equivalent to @workspace command in the text.",
       link: "https://docs.refact.ai/features/ai-chat/",
@@ -183,10 +187,10 @@ const useSearchWorkSpace = (): [Checkbox, () => void] => {
     setSearchWorkspace((prev) => {
       return {
         ...prev,
-        hide: !vecdb || !shouldShow || canUseTools,
+        hide: shouldHide,
       };
     });
-  }, [vecdb, shouldShow, canUseTools]);
+  }, [vecdb, shouldShow, canUseTools, shouldHide]);
 
   const onToggleSearchWorkspace = useCallback(() => {
     setSearchWorkspace((prev) => {

--- a/src/components/ChatForm/useCheckBoxes.ts
+++ b/src/components/ChatForm/useCheckBoxes.ts
@@ -7,9 +7,7 @@ import {
   selectIsStreaming,
   selectMessages,
 } from "../../features/Chat/Thread/selectors";
-import { selectVecdb } from "../../features/Config/configSlice";
 import { createSelector } from "@reduxjs/toolkit";
-import { useCanUseTools } from "../../hooks/useCanUseTools";
 
 const shouldShowSelector = createSelector(
   [selectMessages, selectIsStreaming],
@@ -161,51 +159,7 @@ const useAttachSelectedSnippet = (
   return [attachedSelectedSnippet, onToggleAttachedSelectedSnippet];
 };
 
-const useSearchWorkSpace = (): [Checkbox, () => void] => {
-  const vecdb = useAppSelector(selectVecdb);
-  const { canUseTools, loading } = useCanUseTools();
-  const shouldShow = useAppSelector(shouldShowSelector);
-
-  const shouldHide = useMemo(() => {
-    return !vecdb || !shouldShow || loading || canUseTools;
-  }, [canUseTools, loading, shouldShow, vecdb]);
-
-  const [searchWorkspace, setSearchWorkspace] = useState<Checkbox>({
-    name: "search_workspace",
-    checked: false,
-    label: "Search workspace",
-    disabled: false,
-    hide: shouldHide,
-    info: {
-      text: "Searches all files in your workspace using vector database, uses the whole text in the input box as a search query. Setting this checkbox is equivalent to @workspace command in the text.",
-      link: "https://docs.refact.ai/features/ai-chat/",
-      linkText: "documentation",
-    },
-  });
-
-  useEffect(() => {
-    setSearchWorkspace((prev) => {
-      return {
-        ...prev,
-        hide: shouldHide,
-      };
-    });
-  }, [vecdb, shouldShow, canUseTools, shouldHide]);
-
-  const onToggleSearchWorkspace = useCallback(() => {
-    setSearchWorkspace((prev) => {
-      return {
-        ...prev,
-        checked: !prev.checked,
-      };
-    });
-  }, []);
-
-  return [searchWorkspace, onToggleSearchWorkspace];
-};
-
 export type Checkboxes = {
-  search_workspace: Checkbox;
   file_upload: Checkbox;
   selected_lines: Checkbox;
 };
@@ -217,7 +171,6 @@ export const useCheckboxes = () => {
 
   const [attachedSelectedSnippet, onToggleAttachedSelectedSnippet] =
     useAttachSelectedSnippet(lineSelectionInteracted);
-  const [searchWorkspace, onToggleSearchWorkspace] = useSearchWorkSpace();
 
   const [attachFileCheckboxData, onToggleAttachFile] = useAttachActiveFile(
     fileInteracted,
@@ -226,19 +179,15 @@ export const useCheckboxes = () => {
 
   const checkboxes = useMemo(
     () => ({
-      search_workspace: searchWorkspace,
       file_upload: attachFileCheckboxData,
       selected_lines: attachedSelectedSnippet,
     }),
-    [attachFileCheckboxData, attachedSelectedSnippet, searchWorkspace],
+    [attachFileCheckboxData, attachedSelectedSnippet],
   );
 
   const onToggleCheckbox = useCallback(
     (name: string) => {
       switch (name) {
-        case "search_workspace":
-          onToggleSearchWorkspace();
-          break;
         case "file_upload":
           onToggleAttachFile();
           setFileInteracted(true);
@@ -250,11 +199,7 @@ export const useCheckboxes = () => {
           break;
       }
     },
-    [
-      onToggleAttachFile,
-      onToggleAttachedSelectedSnippet,
-      onToggleSearchWorkspace,
-    ],
+    [onToggleAttachFile, onToggleAttachedSelectedSnippet],
   );
 
   const unCheckAll = useCallback(() => {
@@ -264,16 +209,11 @@ export const useCheckboxes = () => {
     if (attachedSelectedSnippet.checked) {
       onToggleAttachedSelectedSnippet();
     }
-    if (searchWorkspace.checked) {
-      onToggleSearchWorkspace();
-    }
   }, [
     attachFileCheckboxData.checked,
     attachedSelectedSnippet.checked,
     onToggleAttachFile,
     onToggleAttachedSelectedSnippet,
-    onToggleSearchWorkspace,
-    searchWorkspace.checked,
   ]);
 
   return {

--- a/src/components/ChatForm/utils.ts
+++ b/src/components/ChatForm/utils.ts
@@ -17,29 +17,8 @@ export function addCheckboxValuesToInput(
     result = `${checkboxes.selected_lines.value ?? ""}\n` + result;
   }
 
-  // TODO: remove these if it's no longer a feature
-  // if (checkboxes.use_memory.checked && checkboxes.use_memory.hide !== true) {
-  //   result = `@local-notes-to-self\n` + result;
-  // }
-
-  // if (
-  //   checkboxes.lookup_symbols.checked &&
-  //   checkboxes.lookup_symbols.hide !== true
-  // ) {
-  //   result = `@symbols-at ${checkboxes.lookup_symbols.value ?? ""}\n` + result;
-  // }
-
   if (checkboxes.file_upload.checked && checkboxes.file_upload.hide !== true) {
     result = `@file ${checkboxes.file_upload.value ?? ""}\n` + result;
-    // const cmd = vecdb ? "@file-search" : "@file";
-    // result = `${cmd} ${checkboxes.file_upload.value ?? ""}\n` + result;
-  }
-
-  if (
-    checkboxes.search_workspace.checked &&
-    checkboxes.search_workspace.hide !== true
-  ) {
-    result = `@workspace\n` + result;
   }
 
   if (!result.endsWith("\n")) {

--- a/src/hooks/useCanUseTools.ts
+++ b/src/hooks/useCanUseTools.ts
@@ -10,6 +10,7 @@ export const useCanUseTools = () => {
   const toolsRequest = useGetToolsQuery();
   const chatModel = useAppSelector(selectModel);
 
+  // TODO: loading state.
   const canUseTools = useMemo(() => {
     if (!capsRequest.data) return false;
     if (!toolsRequest.data) return false;

--- a/src/hooks/useCanUseTools.ts
+++ b/src/hooks/useCanUseTools.ts
@@ -10,6 +10,10 @@ export const useCanUseTools = () => {
   const toolsRequest = useGetToolsQuery();
   const chatModel = useAppSelector(selectModel);
 
+  const loading = useMemo(() => {
+    return capsRequest.isLoading || toolsRequest.isLoading;
+  }, [capsRequest, toolsRequest]);
+
   // TODO: loading state.
   const canUseTools = useMemo(() => {
     if (!capsRequest.data) return false;
@@ -22,5 +26,8 @@ export const useCanUseTools = () => {
     if ("supports_tools" in model && model.supports_tools) return true;
     return false;
   }, [capsRequest.data, toolsRequest.data, chatModel]);
-  return canUseTools;
+  return {
+    canUseTools,
+    loading,
+  };
 };

--- a/src/hooks/useCapsForToolUse.ts
+++ b/src/hooks/useCapsForToolUse.ts
@@ -79,6 +79,7 @@ export function useCapsForToolUse() {
   }, [currentModel, setCapModel, usableModels, usableModelsForPlan]);
 
   return {
+    data: caps.data,
     usableModels,
     usableModelsForPlan,
     currentModel,

--- a/src/hooks/useCapsForToolUse.ts
+++ b/src/hooks/useCapsForToolUse.ts
@@ -79,11 +79,10 @@ export function useCapsForToolUse() {
   }, [currentModel, setCapModel, usableModels, usableModelsForPlan]);
 
   return {
-    data: caps.data,
     usableModels,
     usableModelsForPlan,
     currentModel,
     setCapModel,
-    loading: caps.isFetching || caps.isLoading,
+    loading: !caps.data && (caps.isFetching || caps.isLoading),
   };
 }

--- a/src/hooks/useGetCapsQuery.ts
+++ b/src/hooks/useGetCapsQuery.ts
@@ -7,5 +7,9 @@ export const useGetCapsQuery = () => {
   const error = useAppSelector(getErrorMessage);
   const pong = useGetPing();
   const skip = !!error || !pong.data;
-  return capsApi.useGetCapsQuery(undefined, { skip });
+  const caps = capsApi.useGetCapsQuery(undefined, {
+    skip,
+  });
+
+  return caps;
 };

--- a/src/services/refact/caps.ts
+++ b/src/services/refact/caps.ts
@@ -43,6 +43,7 @@ export const capsApi = createApi({
       },
     }),
   }),
+  // refetchOnMountOrArgChange: true,
 });
 
 export const capsEndpoints = capsApi.endpoints;

--- a/src/services/refact/caps.ts
+++ b/src/services/refact/caps.ts
@@ -19,7 +19,7 @@ export const capsApi = createApi({
         const state = api.getState() as RootState;
         const port = state.config.lspPort as unknown as number;
         const url = `http://127.0.0.1:${port}${CAPS_URL}`;
-        // return baseQuery(url);
+
         const result = await baseQuery({
           url,
           credentials: "same-origin",
@@ -43,7 +43,6 @@ export const capsApi = createApi({
       },
     }),
   }),
-  // refetchOnMountOrArgChange: true,
 });
 
 export const capsEndpoints = capsApi.endpoints;

--- a/src/services/refact/prompts.ts
+++ b/src/services/refact/prompts.ts
@@ -27,6 +27,7 @@ export const promptsApi = createApi({
           credentials: "same-origin",
           redirect: "follow",
         });
+
         if (result.error) {
           return {
             error: result.error,
@@ -41,6 +42,7 @@ export const promptsApi = createApi({
             },
           };
         }
+
         return { data: result.data.system_prompts };
       },
     }),

--- a/src/services/refact/prompts.ts
+++ b/src/services/refact/prompts.ts
@@ -47,7 +47,6 @@ export const promptsApi = createApi({
       },
     }),
   }),
-  // refetchOnMountOrArgChange: true,
 });
 
 export const promptsEndpoints = promptsApi.endpoints;

--- a/src/services/refact/prompts.ts
+++ b/src/services/refact/prompts.ts
@@ -47,7 +47,7 @@ export const promptsApi = createApi({
       },
     }),
   }),
-  refetchOnMountOrArgChange: true,
+  // refetchOnMountOrArgChange: true,
 });
 
 export const promptsEndpoints = promptsApi.endpoints;


### PR DESCRIPTION
# Prevent UI jumps when opening chat.

## Description


When opening chat the checkboxes and selection boxes would cause the form to jump when the data was resolved.

This is fixed by letting caps and prompts use data that's already there (it'll refresh after a minute), adding a skeleton when waiting for the data.

`search workspace` check box has been removed because `@worksapce` has been removed.


## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

- Step 1: Open chat,
- Step 2: Open another one,
- Step 3: Repeat pressing new chat to see if there are any large jumps.

## Screenshots (if applicable)

<!-- If your changes include UI modifications, attach relevant screenshots here. -->



## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.

## Linked Issues

<!-- List any related issues that this pull request addresses. Use "Fixes #" or "Closes #" to link the PR to specific issues. -->

https://refact.fibery.io/Software_Development/Week1216-by-state-427#Task/UI-Jumping-New-Chat-546

## Additional Notes

<!-- Any additional information that might be useful during the review process. -->
