### PR TITLE
Fix: Integration smartlinks with extra flag are getting disabled on conditions

### DIFF
--- a/src/components/IntegrationsView/IntegrationForm/IntegrationForm.tsx
+++ b/src/components/IntegrationsView/IntegrationForm/IntegrationForm.tsx
@@ -332,6 +332,12 @@ export const IntegrationForm: FC<IntegrationFormProps> = ({
                       integrationPath={
                         integration.data?.integr_config_path ?? ""
                       }
+                      shouldBeDisabled={
+                        smartlink.sl_enable_only_with_tool
+                          ? integration.data?.integr_values === null ||
+                            !shouldIntegrationFormBeDisabled
+                          : false
+                      }
                     />
                   );
                 },

--- a/src/components/SmartLink/SmartLink.tsx
+++ b/src/components/SmartLink/SmartLink.tsx
@@ -12,6 +12,7 @@ export const SmartLink: FC<{
   integrationProject: string;
   isSmall?: boolean;
   isDockerSmartlink?: boolean;
+  shouldBeDisabled?: boolean;
 }> = ({
   smartlink,
   integrationName,
@@ -19,6 +20,7 @@ export const SmartLink: FC<{
   integrationProject,
   isSmall = false,
   isDockerSmartlink = false,
+  shouldBeDisabled,
 }) => {
   const { handleGoTo, handleSmartLink } = useSmartLinks();
 
@@ -69,6 +71,7 @@ export const SmartLink: FC<{
       type="button"
       variant="outline"
       className={styles.magicButton}
+      disabled={shouldBeDisabled}
     >
       {smartlink.sl_chat ? "✨ " : ""}
       {smartlink.sl_label}

--- a/src/services/refact/integrations.ts
+++ b/src/services/refact/integrations.ts
@@ -474,6 +474,7 @@ export type SmartLink = {
   sl_label: string;
   sl_chat?: LspChatMessage[];
   sl_goto?: string;
+  sl_enable_only_with_tool?: boolean;
 };
 
 function isSmartLink(json: unknown): json is SmartLink {
@@ -482,6 +483,11 @@ function isSmartLink(json: unknown): json is SmartLink {
   if (!("sl_label" in json)) return false;
   if (typeof json.sl_label !== "string") return false;
   if (!("sl_chat" in json)) return false;
+  if (
+    "sl_enable_only_with_tool" in json &&
+    typeof json.sl_enable_only_with_tool !== "boolean"
+  )
+    return false;
   if (!Array.isArray(json.sl_chat)) return false;
   if (!json.sl_chat.every(isLspChatMessage)) return false;
   return true;


### PR DESCRIPTION
# Fix: Integration smartlinks with extra flag are getting disabled on conditions

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- Support for additional flag for smartlinks
- [UI Smartlink enable only with tool](https://refact.fibery.io/Software_Development/Release-6.1-433#Task/UI-Smartlink-enable-only-with-tool-589)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->

- Step 1: Try to create a new configuration for integration (for example, postgres)
- Step 2: Smartlink "Test" should be disabled
- Step 3: Apply changes to save integration
- Step 4: Smartlink "Test" should be enabled
- Step 5: Modify any fields within integration form
- Step 6: Smartlink "Test" should be disabled

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.