### PR TITLE
Fix: Displaying correct type of integration in Integration Header

### DIFF
--- a/src/components/IntegrationsView/IntegrationsView.tsx
+++ b/src/components/IntegrationsView/IntegrationsView.tsx
@@ -673,6 +673,8 @@ export const IntegrationsView: FC<IntegrationViewProps> = ({
       const formData = new FormData(event.currentTarget);
       const rawFormValues = Object.fromEntries(formData.entries());
       debugIntegrations(`[DEBUG]: rawFormValues: `, rawFormValues);
+      const [type, rest] =
+        currentNotConfiguredIntegration.integr_name.split("_");
       if (
         "integr_config_path" in rawFormValues &&
         typeof rawFormValues.integr_config_path === "string" &&
@@ -682,19 +684,19 @@ export const IntegrationsView: FC<IntegrationViewProps> = ({
         // making integration-get call and setting the result as currentIntegration
         const commandName = rawFormValues.command_name;
         const configPath = rawFormValues.integr_config_path.replace(
-          "TEMPLATE",
+          rest,
           commandName,
         );
 
         debugIntegrations(
-          `[DEBUG]: config path for \`v1/integration-get\`: `,
+          `[DEBUG INTERMEDIATE PAGE]: config path for \`v1/integration-get\`: `,
           configPath,
         );
 
         const customIntegration: IntegrationWithIconRecord = {
           when_isolated: false,
           on_your_laptop: false,
-          integr_name: `cmdline_${commandName}`,
+          integr_name: `${type}_${commandName}`,
           integr_config_path: configPath,
           project_path: rawFormValues.integr_config_path
             .toString()


### PR DESCRIPTION
# Fix: Displaying correct type of integration in Integration Header

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- Problem: when setting up `service_*` integration, integration header was showing cmdline for all of custom integrations.
- Solution: taking original type of custom integration based on server data instead of having `cmdline` hardcoded.

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.
