### PR TITLE
Fix: using `isAbsolutePath()` to check for paths in link_goto & invalidating of cache for `v1/integration-get`

### DIFF
--- a/src/__tests__/isAbsolutePath.test.ts
+++ b/src/__tests__/isAbsolutePath.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isAbsolutePath } from "./isAbsolutePath";
+import { isAbsolutePath } from "../utils/isAbsolutePath";
 
 describe("isAbsolutePath", () => {
   it("should return true for Windows absolute paths", () => {

--- a/src/app/middleware.ts
+++ b/src/app/middleware.ts
@@ -57,6 +57,19 @@ startListening({
   },
 });
 
+// TODO: think about better cache invalidation approach instead of listening for an action dispatching globally
+startListening({
+  matcher: isAnyOf((d: unknown): d is ReturnType<typeof newIntegrationChat> =>
+    newIntegrationChat.match(d),
+  ),
+  effect: (_action, listenerApi) => {
+    [integrationsApi.util.resetApiState()].forEach((api) =>
+      listenerApi.dispatch(api),
+    );
+    listenerApi.dispatch(clearError());
+  },
+});
+
 startListening({
   // TODO: figure out why this breaks the tests when it's not a function :/
   matcher: isAnyOf(isRejected),

--- a/src/debugConfig.ts
+++ b/src/debugConfig.ts
@@ -7,16 +7,18 @@ export const debugApp = createDebug("app");
 export const debugComponent = createDebug("component");
 export const debugIntegrations = createDebug("integrations");
 
-createDebug.enable("refact");
-debugRefact(
-  `Debugging: ${debugNamespaces !== "undefined" ? "enabled" : "disabled"}`,
-);
-if (debugNamespaces && debugNamespaces !== "undefined") {
-  if (debugNamespaces === "*") {
-    debugRefact("Enabling debug logging for all namespaces");
-    createDebug.enable("*");
-  } else {
-    debugRefact(`Enabling debug logging for namespaces [${debugNamespaces}]`);
-    createDebug.enable(debugNamespaces);
+if (typeof window !== "undefined" && process.env.NODE_ENV === "development") {
+  createDebug.enable("refact");
+  debugRefact(
+    `Debugging: ${debugNamespaces !== "undefined" ? "enabled" : "disabled"}`,
+  );
+  if (debugNamespaces && debugNamespaces !== "undefined") {
+    if (debugNamespaces === "*") {
+      debugRefact("Enabling debug logging for all namespaces");
+      createDebug.enable("*");
+    } else {
+      debugRefact(`Enabling debug logging for namespaces [${debugNamespaces}]`);
+      createDebug.enable(debugNamespaces);
+    }
   }
 }

--- a/src/debugConfig.ts
+++ b/src/debugConfig.ts
@@ -2,20 +2,21 @@ import createDebug from "debug";
 
 const debugNamespaces = process.env.DEBUG;
 
-export const debugRoot = createDebug("root"); // debugRoot is to log verbosely root settings of debug module
+export const debugRefact = createDebug("refact"); // debugRoot is to log verbosely root settings of debug module
 export const debugApp = createDebug("app");
 export const debugComponent = createDebug("component");
 export const debugIntegrations = createDebug("integrations");
 
-createDebug.enable("root");
-debugRoot(`Debugging: ${debugNamespaces ? "enabled" : "disabled"}`);
-
-if (debugNamespaces) {
+createDebug.enable("refact");
+debugRefact(
+  `Debugging: ${debugNamespaces !== "undefined" ? "enabled" : "disabled"}`,
+);
+if (debugNamespaces && debugNamespaces !== "undefined") {
   if (debugNamespaces === "*") {
-    debugRoot("Enabling debug logging for all namespaces");
+    debugRefact("Enabling debug logging for all namespaces");
     createDebug.enable("*");
   } else {
-    debugRoot(`Enabling debug logging for namespaces [${debugNamespaces}]`);
+    debugRefact(`Enabling debug logging for namespaces [${debugNamespaces}]`);
     createDebug.enable(debugNamespaces);
   }
 }

--- a/src/hooks/useLinksFromLsp.ts
+++ b/src/hooks/useLinksFromLsp.ts
@@ -26,6 +26,7 @@ import { setError } from "../features/Errors/errorsSlice";
 import { setInformation } from "../features/Errors/informationSlice";
 import { debugIntegrations } from "../debugConfig";
 import { telemetryApi } from "../services/refact/telemetry";
+import { isAbsolutePath } from "../utils";
 
 export function useGetLinksFromLsp() {
   const isStreaming = useAppSelector(selectIsStreaming);
@@ -140,17 +141,13 @@ export function useLinksFromLsp() {
         "link_goto" in link &&
         link.link_goto !== undefined
       ) {
-        const isIntegrationNameInPayload = (name: string) => {
-          return !/[\\:]/.test(name);
-        };
-
         const [action, ...payloadParts] = link.link_goto.split(":");
         const payload = payloadParts.join(":");
         if (action.toLowerCase() === "settings") {
           debugIntegrations(
             `[DEBUG]: this goto is integrations one, dispatching integration data`,
           );
-          if (isIntegrationNameInPayload(payload)) {
+          if (!isAbsolutePath(payload)) {
             dispatch(
               setIntegrationData({
                 name: payload,

--- a/src/utils/isAbsolutePath.test.ts
+++ b/src/utils/isAbsolutePath.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { isAbsolutePath } from "./isAbsolutePath";
+
+describe("isAbsolutePath", () => {
+  it("should return true for Windows absolute paths", () => {
+    expect(
+      isAbsolutePath(
+        "\\\\?\\C:\\Users\\andre\\.config\\integrations.d\\cmdline_example.yaml",
+      ),
+    ).toBe(true);
+    expect(isAbsolutePath("D:\\Folder\\Subfolder")).toBe(true);
+  });
+
+  it("should return true for Unix absolute paths", () => {
+    expect(isAbsolutePath("/usr/local/bin")).toBe(true);
+    expect(
+      isAbsolutePath(
+        "/Users/andre/.config/integrations.d/cmdline_example.yaml",
+      ),
+    ).toBe(true);
+  });
+
+  it("should return true for UNC paths", () => {
+    expect(isAbsolutePath("\\\\Server\\Share")).toBe(true);
+    expect(isAbsolutePath("//Server/Share")).toBe(true);
+  });
+
+  it("should return false for relative paths", () => {
+    expect(isAbsolutePath("relative/path")).toBe(false);
+    expect(isAbsolutePath("folder\\subfolder")).toBe(false);
+    expect(isAbsolutePath("./relative")).toBe(false);
+    expect(isAbsolutePath("../relative")).toBe(false);
+  });
+
+  it("should return false for empty string", () => {
+    expect(isAbsolutePath("")).toBe(false);
+  });
+});


### PR DESCRIPTION
# Fix: using `isAbsolutePath()` to check for paths in link_goto & invalidating of cache for `v1/integration-get`

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- Problem: previous implementation was not covering UNIX paths, also, `v1/integration-get` was not invalidating cache properly.
- Solution: using existing `isAbsolutePath()` and written tests for that function to be sure that it works correctly. Also made a listener in middleware to reset API state to make sure that `v1/integration-get` will be triggered on return.
- [VERIFIED AND STILL THERE -- UI save and return to config, doesn't load the updates values](https://refact.fibery.io/Software_Development/Week1223-by-state-436#Task/508)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->

- Step 1: Open working postgres configuration
- Step 2: Click on "Test" smartlink
- Step 3: Ask model to change database name (or any other property) to be different
- Step 4: When [Save and return] link is available, click on that one
- Step 5: Values of configuration should be updated and correct integration should be opened.

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.