### PR TITLE
Fix: If model doesn't support tools, exclusion from list of usable models & simplification of props for ChatForm

### DIFF
--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -121,10 +121,6 @@ export const Chat: React.FC<ChatProps> = ({
 
         <ChatForm
           key={chatId} // TODO: think of how can we not trigger re-render on chatId change (checkboxes)
-          chatId={chatId}
-          isStreaming={isStreaming}
-          // TODO: move this
-          showControls={messages.length === 0 && !isStreaming}
           onSubmit={handleSummit}
           onClose={maybeSendToSidebar}
           onToolConfirm={confirmToolUsage}

--- a/src/components/ChatForm/ChatControls.tsx
+++ b/src/components/ChatForm/ChatControls.tsx
@@ -167,7 +167,7 @@ export const ChatControls: React.FC<ChatControlsProps> = ({
   );
 
   const showControls = useMemo(
-    () => messages.length > 0 && !isStreaming,
+    () => messages.length === 0 && !isStreaming,
     [isStreaming, messages],
   );
 

--- a/src/components/ChatForm/ChatControls.tsx
+++ b/src/components/ChatForm/ChatControls.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { Text, Flex, HoverCard, Link, Skeleton, Box } from "@radix-ui/themes";
 import { Select } from "../Select";
 import { type Config } from "../../features/Config/configSlice";
@@ -10,7 +10,13 @@ import { Checkbox } from "../Checkbox";
 import { QuestionMarkCircledIcon } from "@radix-ui/react-icons";
 import { useTourRefs } from "../../features/Tour";
 import { ToolUseSwitch } from "./ToolUseSwitch";
-import { ToolUse, selectToolUse, setToolUse } from "../../features/Chat/Thread";
+import {
+  ToolUse,
+  selectIsStreaming,
+  selectMessages,
+  selectToolUse,
+  setToolUse,
+} from "../../features/Chat/Thread";
 import { useAppSelector, useAppDispatch, useCapsForToolUse } from "../../hooks";
 
 const CapsSelect: React.FC = () => {
@@ -78,7 +84,6 @@ export type ChatControlsProps = {
   ) => void;
 
   host: Config["host"];
-  showControls: boolean;
 };
 
 const ChatControlCheckBox: React.FC<{
@@ -150,14 +155,20 @@ export const ChatControls: React.FC<ChatControlsProps> = ({
   checkboxes,
   onCheckedChange,
   host,
-  showControls,
 }) => {
   const refs = useTourRefs();
   const dispatch = useAppDispatch();
+  const isStreaming = useAppSelector(selectIsStreaming);
+  const messages = useAppSelector(selectMessages);
   const toolUse = useAppSelector(selectToolUse);
   const onSetToolUse = useCallback(
     (value: ToolUse) => dispatch(setToolUse(value)),
     [dispatch],
+  );
+
+  const showControls = useMemo(
+    () => messages.length > 0 && !isStreaming,
+    [isStreaming, messages],
   );
 
   return (

--- a/src/components/ChatForm/ChatForm.stories.tsx
+++ b/src/components/ChatForm/ChatForm.stories.tsx
@@ -55,8 +55,6 @@ const meta: Meta<typeof ChatForm> = {
       // eslint-disable-next-line no-console
       console.log("onclose called");
     },
-    isStreaming: false,
-    showControls: true,
   },
   decorators: [
     (Children) => {

--- a/src/components/ChatForm/ChatForm.test.tsx
+++ b/src/components/ChatForm/ChatForm.test.tsx
@@ -28,10 +28,7 @@ const noop = () => ({});
 
 const App: React.FC<Partial<ChatFormProps>> = ({ ...props }) => {
   const defaultProps: ChatFormProps = {
-    chatId: "chatId",
     onSubmit: (_str: string) => ({}),
-    isStreaming: false,
-    showControls: true,
     onToolConfirm: noop,
     ...props,
   };
@@ -81,23 +78,20 @@ describe("ChatForm", () => {
       path: "/Users/refact/projects/print1.py",
       basename: "print1.py",
     };
-    const { user, ...app } = render(
-      <App chatId="test-3" onSubmit={fakeOnSubmit} />,
-      {
-        preloadedState: {
-          selected_snippet: snippet,
-          active_file: {
-            name: "foo.txt",
-            cursor: 2,
-            path: "foo.txt",
-            line1: 1,
-            line2: 3,
-            can_paste: true,
-          },
-          config: { host: "vscode", themeProps: {}, lspPort: 8001 },
+    const { user, ...app } = render(<App onSubmit={fakeOnSubmit} />, {
+      preloadedState: {
+        selected_snippet: snippet,
+        active_file: {
+          name: "foo.txt",
+          cursor: 2,
+          path: "foo.txt",
+          line1: 1,
+          line2: 3,
+          can_paste: true,
         },
+        config: { host: "vscode", themeProps: {}, lspPort: 8001 },
       },
-    );
+    });
 
     const label = app.queryByText(/Selected \d* lines/);
     expect(label).not.toBeNull();

--- a/src/components/ChatForm/ChatForm.tsx
+++ b/src/components/ChatForm/ChatForm.tsx
@@ -33,14 +33,12 @@ import { ToolConfirmation } from "./ToolConfirmation";
 import { getPauseReasonsWithPauseStatus } from "../../features/ToolConfirmation/confirmationSlice";
 import { AttachFileButton, FileList } from "../Dropzone";
 import { useAttachedImages } from "../../hooks/useAttachedImages";
+import { selectIsStreaming } from "../../features/Chat";
 
 export type ChatFormProps = {
   onSubmit: (str: string) => void;
   onClose?: () => void;
   className?: string;
-  isStreaming: boolean;
-  showControls: boolean;
-  chatId: string;
   onToolConfirm: () => void;
 };
 
@@ -48,11 +46,10 @@ export const ChatForm: React.FC<ChatFormProps> = ({
   onSubmit,
   onClose,
   className,
-  isStreaming,
-  showControls,
   onToolConfirm,
 }) => {
   const dispatch = useAppDispatch();
+  const isStreaming = useAppSelector(selectIsStreaming);
   const config = useConfig();
   const error = useAppSelector(getErrorMessage);
   const information = useAppSelector(getInformationMessage);
@@ -297,7 +294,6 @@ export const ChatForm: React.FC<ChatFormProps> = ({
       <ChatControls
         host={config.host}
         checkboxes={checkboxes}
-        showControls={showControls}
         onCheckedChange={onToggleCheckbox}
       />
     </Card>

--- a/src/hooks/useCapsForToolUse.ts
+++ b/src/hooks/useCapsForToolUse.ts
@@ -38,8 +38,11 @@ export function useCapsForToolUse() {
     const models = caps.data?.code_chat_models ?? {};
     const items = Object.entries(models).reduce<string[]>(
       (acc, [key, value]) => {
-        if (toolUse !== "agent") return [...acc, key];
-        if (value.supports_agent) return [...acc, key];
+        if (toolUse === "explore" && value.supports_tools) {
+          return [...acc, key];
+        }
+        if (toolUse === "agent" && value.supports_agent) return [...acc, key];
+        if (toolUse === "quick") return [...acc, key];
         return acc;
       },
       [],


### PR DESCRIPTION
# Fix: If model doesn't support tools, exclusion from list of usable models & simplification of props for ChatForm

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- Problem: If tool use was set to "Explore", models which don't support tools were not filtered out.
- Solution: Adjustment of `usableModels` reduce call to include that condition as well.
- Extra: Small refactoring of ChatForm, Chat components, reduction of props getting passed down to the components tree (now consuming state directly from RTK Store)
- Any background context or related links?
  - [No tools models behavior](https://refact.fibery.io/Software_Development/Task/No-tools-models-behavior-613)
  - [Chat mode in IDE](https://refact.fibery.io/Software_Development/Week1223-by-state-436#Task/Chat-mode-in-IDE-614)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.