### PR TITLE
Feat: Support of denying tools on run from Tool Confirmation popup

### DIFF
--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -45,8 +45,7 @@ export const Chat: React.FC<ChatProps> = ({
   const caps = useGetCapsQuery();
 
   const chatId = useAppSelector(selectChatId);
-  const { submit, abort, retryFromIndex, confirmToolUsage } =
-    useSendChatRequest();
+  const { submit, abort, retryFromIndex } = useSendChatRequest();
 
   const chatToolUse = useAppSelector(getSelectedToolUse);
   const dispatch = useAppDispatch();
@@ -123,7 +122,6 @@ export const Chat: React.FC<ChatProps> = ({
           key={chatId} // TODO: think of how can we not trigger re-render on chatId change (checkboxes)
           onSubmit={handleSummit}
           onClose={maybeSendToSidebar}
-          onToolConfirm={confirmToolUsage}
         />
 
         <Flex justify="between" pl="1" pr="1" pt="1">

--- a/src/components/ChatForm/ChatForm.test.tsx
+++ b/src/components/ChatForm/ChatForm.test.tsx
@@ -24,12 +24,9 @@ const handlers = [
 
 server.use(...handlers);
 
-const noop = () => ({});
-
 const App: React.FC<Partial<ChatFormProps>> = ({ ...props }) => {
   const defaultProps: ChatFormProps = {
     onSubmit: (_str: string) => ({}),
-    onToolConfirm: noop,
     ...props,
   };
 

--- a/src/components/ChatForm/ChatForm.tsx
+++ b/src/components/ChatForm/ChatForm.tsx
@@ -39,14 +39,12 @@ export type ChatFormProps = {
   onSubmit: (str: string) => void;
   onClose?: () => void;
   className?: string;
-  onToolConfirm: () => void;
 };
 
 export const ChatForm: React.FC<ChatFormProps> = ({
   onSubmit,
   onClose,
   className,
-  onToolConfirm,
 }) => {
   const dispatch = useAppDispatch();
   const isStreaming = useAppSelector(selectIsStreaming);
@@ -180,10 +178,6 @@ export const ChatForm: React.FC<ChatFormProps> = ({
     [handleHelpInfo, setValue, setFileInteracted, setLineSelectionInteracted],
   );
 
-  const handleToolConfirmation = useCallback(() => {
-    onToolConfirm();
-  }, [onToolConfirm]);
-
   useEffect(() => {
     if (isSendImmediately) {
       handleSubmit();
@@ -212,10 +206,7 @@ export const ChatForm: React.FC<ChatFormProps> = ({
 
   if (!isStreaming && pauseReasonsWithPause.pause) {
     return (
-      <ToolConfirmation
-        pauseReasons={pauseReasonsWithPause.pauseReasons}
-        onConfirm={handleToolConfirmation}
-      />
+      <ToolConfirmation pauseReasons={pauseReasonsWithPause.pauseReasons} />
     );
   }
 

--- a/src/components/ChatForm/ToolConfirmation.tsx
+++ b/src/components/ChatForm/ToolConfirmation.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { PauseReason } from "../../features/ToolConfirmation/confirmationSlice";
 import {
   useAppDispatch,
+  useSendChatRequest,
   // useEventsBusForIDE
 } from "../../hooks";
 import { Card, Button, Text, Flex } from "@radix-ui/themes";
@@ -12,7 +13,6 @@ import { push } from "../../features/Pages/pagesSlice";
 
 type ToolConfirmationProps = {
   pauseReasons: PauseReason[];
-  onConfirm: () => void;
 };
 
 const getConfirmationalMessage = (
@@ -50,7 +50,6 @@ const getConfirmationalMessage = (
 
 export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({
   pauseReasons,
-  onConfirm,
 }) => {
   const dispatch = useAppDispatch();
 
@@ -66,6 +65,8 @@ export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({
     (_, i) => types[i] === "confirmation",
   );
   const denialCommands = commands.filter((_, i) => types[i] === "denial");
+
+  const { rejectToolUsage, confirmToolUsage } = useSendChatRequest();
 
   const message = getConfirmationalMessage(
     commands,
@@ -107,10 +108,25 @@ export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({
             </Text>
           </Text>
         </Flex>
-        <Flex align="end" justify="center" gap="1" direction="row">
-          <Button color="grass" variant="surface" size="1" onClick={onConfirm}>
+        <Flex align="end" justify="start" gap="2" direction="row">
+          <Button
+            color="grass"
+            variant="surface"
+            size="1"
+            onClick={confirmToolUsage}
+          >
             {allConfirmational ? "Confirm" : "Continue"}
           </Button>
+          {allConfirmational && (
+            <Button
+              color="red"
+              variant="surface"
+              size="1"
+              onClick={rejectToolUsage}
+            >
+              Deny
+            </Button>
+          )}
         </Flex>
       </Flex>
     </Card>

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -21,7 +21,7 @@ import {
   useEventsBusForIDE,
 } from "../../hooks";
 import { useWindowDimensions } from "../../hooks/useWindowDimensions";
-import { clearPauseReasonsAndConfirmTools } from "../../features/ToolConfirmation/confirmationSlice";
+import { clearPauseReasonsAndHandleToolsStatus } from "../../features/ToolConfirmation/confirmationSlice";
 import { telemetryApi } from "../../services/refact/telemetry";
 
 export type DashboardTab = {
@@ -121,7 +121,12 @@ export const Toolbar = ({ activeTab }: ToolbarProps) => {
 
   const onCreateNewChat = useCallback(() => {
     dispatch(newChatAction());
-    dispatch(clearPauseReasonsAndConfirmTools(false));
+    dispatch(
+      clearPauseReasonsAndHandleToolsStatus({
+        wasInteracted: false,
+        confirmationStatus: true,
+      }),
+    );
     handleNavigation("chat");
     void sendTelemetryEvent({
       scope: `openNewChat`,

--- a/src/features/ToolConfirmation/confirmationSlice.ts
+++ b/src/features/ToolConfirmation/confirmationSlice.ts
@@ -10,13 +10,24 @@ export type PauseReason = {
 export type ConfirmationState = {
   pauseReasons: PauseReason[];
   pause: boolean;
-  toolsConfirmed: boolean;
+  status: {
+    wasInteracted: boolean;
+    confirmationStatus: boolean;
+  };
 };
 
 const initialState: ConfirmationState = {
   pauseReasons: [],
   pause: false,
-  toolsConfirmed: false,
+  status: {
+    wasInteracted: false,
+    confirmationStatus: true,
+  },
+};
+
+type ConfirmationActionPayload = {
+  wasInteracted: boolean;
+  confirmationStatus: boolean;
 };
 
 export const confirmationSlice = createSlice({
@@ -27,23 +38,28 @@ export const confirmationSlice = createSlice({
       state.pause = true;
       state.pauseReasons = action.payload;
     },
-    clearPauseReasonsAndConfirmTools(state, action: PayloadAction<boolean>) {
+    clearPauseReasonsAndHandleToolsStatus(
+      state,
+      action: PayloadAction<ConfirmationActionPayload>,
+    ) {
       state.pause = false;
       state.pauseReasons = [];
-      state.toolsConfirmed = action.payload;
+      state.status = action.payload;
     },
   },
   selectors: {
     getPauseReasonsWithPauseStatus: (state) => state,
-    getToolsConfirmationStatus: (state) => state.toolsConfirmed,
+    getToolsInteractionStatus: (state) => state.status.wasInteracted,
+    getToolsConfirmationStatus: (state) => state.status.confirmationStatus,
     getConfirmationPauseStatus: (state) => state.pause,
   },
 });
 
-export const { setPauseReasons, clearPauseReasonsAndConfirmTools } =
+export const { setPauseReasons, clearPauseReasonsAndHandleToolsStatus } =
   confirmationSlice.actions;
 export const {
   getPauseReasonsWithPauseStatus,
   getToolsConfirmationStatus,
+  getToolsInteractionStatus,
   getConfirmationPauseStatus,
 } = confirmationSlice.selectors;

--- a/src/hooks/useGoToLink.ts
+++ b/src/hooks/useGoToLink.ts
@@ -7,7 +7,7 @@ import { useAppSelector } from "./useAppSelector";
 import { selectIntegration } from "../features/Chat/Thread/selectors";
 import { debugIntegrations } from "../debugConfig";
 import { newChatAction } from "../features/Chat/Thread/actions";
-import { clearPauseReasonsAndConfirmTools } from "../features/ToolConfirmation/confirmationSlice";
+import { clearPauseReasonsAndHandleToolsStatus } from "../features/ToolConfirmation/confirmationSlice";
 
 export function useGoToLink() {
   const dispatch = useAppDispatch();
@@ -55,7 +55,12 @@ export function useGoToLink() {
 
         case "newchat": {
           dispatch(newChatAction());
-          dispatch(clearPauseReasonsAndConfirmTools(false));
+          dispatch(
+            clearPauseReasonsAndHandleToolsStatus({
+              wasInteracted: false,
+              confirmationStatus: true,
+            }),
+          );
           dispatch(popBackTo({ name: "history" }));
           dispatch(push({ name: "chat" }));
           return;

--- a/src/services/refact/chat.ts
+++ b/src/services/refact/chat.ts
@@ -45,6 +45,7 @@ type SendChatArgs = {
   port?: number;
   apiKey?: string | null;
   // isConfig?: boolean;
+  toolsConfirmed?: boolean;
   integration?: IntegrationMeta | null;
   mode?: LspChatMode; // used for chat actions
 } & StreamArgs;
@@ -113,6 +114,7 @@ export async function sendChat({
   tools,
   port = 8001,
   apiKey,
+  toolsConfirmed = true,
   // isConfig = false,
   integration,
   mode,
@@ -137,6 +139,7 @@ export async function sendChat({
     tools,
     max_tokens: 2048,
     only_deterministic_messages,
+    tools_confirmation: toolsConfirmed,
     // chat_id,
     meta: {
       chat_id,


### PR DESCRIPTION
# Feat: Support of denying tools on run from Tool Confirmation popup

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- Problem: even for commands that need confirmation, users were not able to just deny tool without resubmitting previous message.
- Solution: adding support for denying tools just within chat.
- Extra: refactoring of Chat, ChatForm, ToolConfirmation components, taking `rejectToolUsage` and `confirmToolUsage` were needed without extra prop drilling.
- [Implement tool refusal](https://refact.fibery.io/Software_Development/Week1223-by-state-436#Task/Implement-tool-refusal-621)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.