### PR TITLE
Fix: hiding uncommitted changes warning if chat mode is explore

### DIFF
--- a/src/components/ChatContent/ChatContent.tsx
+++ b/src/components/ChatContent/ChatContent.tsx
@@ -45,7 +45,6 @@ export const ChatContent: React.FC<ChatContentProps> = ({
   const messages = useAppSelector(selectMessages);
   const isStreaming = useAppSelector(selectIsStreaming);
   const thread = useAppSelector(selectThread);
-  const threadToolUse = thread.tool_use;
   const isConfig = thread.mode === "CONFIGURE";
   const isWaiting = useAppSelector(selectIsWaiting);
   const [sendTelemetryEvent] =
@@ -106,7 +105,7 @@ export const ChatContent: React.FC<ChatContentProps> = ({
       <Flex direction="column" className={styles.content} p="2" gap="1">
         {messages.length === 0 && <PlaceHolderText />}
         {renderMessages(messages, onRetryWrapper)}
-        {threadToolUse === "agent" && <UncommittedChangesWarning />}
+        <UncommittedChangesWarning />
 
         <Container py="4">
           <Spinner spinning={isWaiting} />

--- a/src/components/ChatContent/ChatContent.tsx
+++ b/src/components/ChatContent/ChatContent.tsx
@@ -105,7 +105,7 @@ export const ChatContent: React.FC<ChatContentProps> = ({
       <Flex direction="column" className={styles.content} p="2" gap="1">
         {messages.length === 0 && <PlaceHolderText />}
         {renderMessages(messages, onRetryWrapper)}
-        <UncommittedChangesWarning />
+        {thread.mode !== "EXPLORE" && <UncommittedChangesWarning />}
 
         <Container py="4">
           <Spinner spinning={isWaiting} />

--- a/src/components/ChatContent/ChatContent.tsx
+++ b/src/components/ChatContent/ChatContent.tsx
@@ -45,6 +45,7 @@ export const ChatContent: React.FC<ChatContentProps> = ({
   const messages = useAppSelector(selectMessages);
   const isStreaming = useAppSelector(selectIsStreaming);
   const thread = useAppSelector(selectThread);
+  const threadToolUse = thread.tool_use;
   const isConfig = thread.mode === "CONFIGURE";
   const isWaiting = useAppSelector(selectIsWaiting);
   const [sendTelemetryEvent] =
@@ -105,7 +106,7 @@ export const ChatContent: React.FC<ChatContentProps> = ({
       <Flex direction="column" className={styles.content} p="2" gap="1">
         {messages.length === 0 && <PlaceHolderText />}
         {renderMessages(messages, onRetryWrapper)}
-        {thread.mode !== "EXPLORE" && <UncommittedChangesWarning />}
+        {threadToolUse === "agent" && <UncommittedChangesWarning />}
 
         <Container py="4">
           <Spinner spinning={isWaiting} />

--- a/src/hooks/useLinksFromLsp.ts
+++ b/src/hooks/useLinksFromLsp.ts
@@ -18,7 +18,6 @@ import {
   selectMessages,
   selectModel,
   selectThreadMode,
-  selectThreadToolUse,
   setIntegrationData,
 } from "../features/Chat";
 import { useGoToLink } from "./useGoToLink";
@@ -35,7 +34,6 @@ export function useGetLinksFromLsp() {
   const chatId = useAppSelector(selectChatId);
   const maybeIntegration = useAppSelector(selectIntegration);
   const threadMode = useAppSelector(selectThreadMode);
-  const toolUse = useAppSelector(selectThreadToolUse);
 
   // TODO: add the model
   const caps = useGetCapsQuery();
@@ -57,19 +55,10 @@ export function useGetLinksFromLsp() {
       messages.length > 0 && isUserMessage(messages[messages.length - 1]);
     if (!model) return true;
     if (!caps.data) return true;
-    if (toolUse !== "agent") return true;
     return (
       isStreaming || isWaiting || unCalledTools || lastMessageIsUserMessage
     );
-  }, [
-    caps.data,
-    isStreaming,
-    isWaiting,
-    messages,
-    model,
-    toolUse,
-    unCalledTools,
-  ]);
+  }, [caps.data, isStreaming, isWaiting, messages, model, unCalledTools]);
 
   const linksResult = linksApi.useGetLinksForChatQuery(
     {


### PR DESCRIPTION
# Fix: hiding uncommitted changes warning if chat mode is explore

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- [Uncommitted warning gets dragged along in "Explore" mode](https://refact.fibery.io/Software_Development/Task/Uncommitted-warning-gets-dragged-along-in-Explore-mode-641)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.