### PR TITLE
Fix: Better Tool Confirmation popup

### DIFF
--- a/src/app/middleware.ts
+++ b/src/app/middleware.ts
@@ -27,6 +27,7 @@ import { resetAttachedImagesSlice } from "../features/AttachedImages";
 import { nextTip } from "../features/TipOfTheDay";
 import { telemetryApi } from "../services/refact/telemetry";
 import { CONFIG_PATH_URL, FULL_PATH_URL } from "../services/refact/consts";
+import { resetConfirmationInteractedState } from "../features/ToolConfirmation/confirmationSlice";
 
 export const listenerMiddleware = createListenerMiddleware();
 const startListening = listenerMiddleware.startListening.withTypes<
@@ -51,6 +52,7 @@ startListening({
       commandsApi.util.resetApiState(),
       diffApi.util.resetApiState(),
       resetAttachedImagesSlice(),
+      resetConfirmationInteractedState(),
     ].forEach((api) => listenerApi.dispatch(api));
 
     listenerApi.dispatch(clearError());

--- a/src/components/ChatForm/ToolConfirmation.tsx
+++ b/src/components/ChatForm/ToolConfirmation.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import type { PauseReason } from "../../features/ToolConfirmation/confirmationSlice";
 import {
   useAppDispatch,
   useSendChatRequest,
@@ -10,9 +9,10 @@ import { Markdown } from "../Markdown";
 import { Link } from "../Link";
 import styles from "./ToolConfirmation.module.css";
 import { push } from "../../features/Pages/pagesSlice";
+import { ToolConfirmationPauseReason } from "../../services/refact";
 
 type ToolConfirmationProps = {
-  pauseReasons: PauseReason[];
+  pauseReasons: ToolConfirmationPauseReason[];
 };
 
 const getConfirmationalMessage = (
@@ -53,12 +53,17 @@ export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({
 }) => {
   const dispatch = useAppDispatch();
 
-  // const { openIntegrationsFile } = useEventsBusForIDE();
-
   const commands = pauseReasons.map((reason) => reason.command);
   const rules = pauseReasons.map((reason) => reason.rule);
   const types = pauseReasons.map((reason) => reason.type);
   const toolCallIds = pauseReasons.map((reason) => reason.tool_call_id);
+
+  const integrationPaths = pauseReasons.map(
+    (reason) => reason.integr_config_path,
+  );
+
+  // assuming that at least one path out of all objects is not null so we can show up the link
+  const maybeIntegrationPath = integrationPaths.find((path) => path !== null);
 
   const allConfirmational = types.every((type) => type === "confirmation");
   const confirmationalCommands = commands.filter(
@@ -96,16 +101,24 @@ export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({
           ))}
           <Text className={styles.ToolConfirmationText}>
             <Markdown>{message.concat("\n\n")}</Markdown>
-            <Text className={styles.ToolConfirmationText} mt="3">
-              You can modify the ruleset on{" "}
-              <Link
-                onClick={() => {
-                  dispatch(push({ name: "integrations page" }));
-                }}
-              >
-                Configuration Page
-              </Link>
-            </Text>
+            {maybeIntegrationPath && (
+              <Text className={styles.ToolConfirmationText} mt="3">
+                You can modify the ruleset on{" "}
+                <Link
+                  onClick={() => {
+                    dispatch(
+                      push({
+                        name: "integrations page",
+                        integrationPath: maybeIntegrationPath,
+                        wasOpenedThroughChat: true,
+                      }),
+                    );
+                  }}
+                >
+                  Configuration Page
+                </Link>
+              </Text>
+            )}
           </Text>
         </Flex>
         <Flex align="end" justify="start" gap="2" direction="row">

--- a/src/features/ToolConfirmation/confirmationSlice.ts
+++ b/src/features/ToolConfirmation/confirmationSlice.ts
@@ -38,6 +38,11 @@ export const confirmationSlice = createSlice({
       state.pause = true;
       state.pauseReasons = action.payload;
     },
+    resetConfirmationInteractedState(state) {
+      state.status.wasInteracted = false;
+      state.pause = false;
+      state.pauseReasons = [];
+    },
     clearPauseReasonsAndHandleToolsStatus(
       state,
       action: PayloadAction<ConfirmationActionPayload>,
@@ -55,8 +60,11 @@ export const confirmationSlice = createSlice({
   },
 });
 
-export const { setPauseReasons, clearPauseReasonsAndHandleToolsStatus } =
-  confirmationSlice.actions;
+export const {
+  setPauseReasons,
+  resetConfirmationInteractedState,
+  clearPauseReasonsAndHandleToolsStatus,
+} = confirmationSlice.actions;
 export const {
   getPauseReasonsWithPauseStatus,
   getToolsConfirmationStatus,

--- a/src/features/ToolConfirmation/confirmationSlice.ts
+++ b/src/features/ToolConfirmation/confirmationSlice.ts
@@ -1,14 +1,8 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-
-export type PauseReason = {
-  type: "confirmation" | "denial";
-  command: string;
-  rule: string;
-  tool_call_id: string;
-};
+import { ToolConfirmationPauseReason } from "../../events";
 
 export type ConfirmationState = {
-  pauseReasons: PauseReason[];
+  pauseReasons: ToolConfirmationPauseReason[];
   pause: boolean;
   status: {
     wasInteracted: boolean;
@@ -34,7 +28,10 @@ export const confirmationSlice = createSlice({
   name: "confirmation",
   initialState,
   reducers: {
-    setPauseReasons(state, action: PayloadAction<PauseReason[]>) {
+    setPauseReasons(
+      state,
+      action: PayloadAction<ToolConfirmationPauseReason[]>,
+    ) {
       state.pause = true;
       state.pauseReasons = action.payload;
     },

--- a/src/hooks/useSendChatRequest.ts
+++ b/src/hooks/useSendChatRequest.ts
@@ -156,6 +156,7 @@ export const useSendChatRequest = () => {
       threadMode,
       wasInteracted,
       areToolsConfirmed,
+      currentMessages,
       abortControllers,
       incrementIfLastMessageIsFromUser,
       triggerCheckForConfirmation,

--- a/src/hooks/useSendChatRequest.ts
+++ b/src/hooks/useSendChatRequest.ts
@@ -122,7 +122,7 @@ export const useSendChatRequest = () => {
         const toolCalls = lastMessage.tool_calls;
         const confirmationResponse = await triggerCheckForConfirmation({
           tool_calls: toolCalls,
-          messages: currentMessages,
+          messages: messages,
         }).unwrap();
         if (confirmationResponse.pause) {
           dispatch(setPauseReasons(confirmationResponse.pause_reasons));
@@ -156,7 +156,6 @@ export const useSendChatRequest = () => {
       threadMode,
       wasInteracted,
       areToolsConfirmed,
-      currentMessages,
       abortControllers,
       incrementIfLastMessageIsFromUser,
       triggerCheckForConfirmation,

--- a/src/hooks/useSendChatRequest.ts
+++ b/src/hooks/useSendChatRequest.ts
@@ -120,8 +120,10 @@ export const useSendChatRequest = () => {
         lastMessage.tool_calls
       ) {
         const toolCalls = lastMessage.tool_calls;
-        const confirmationResponse =
-          await triggerCheckForConfirmation(toolCalls).unwrap();
+        const confirmationResponse = await triggerCheckForConfirmation({
+          tool_calls: toolCalls,
+          messages: currentMessages,
+        }).unwrap();
         if (confirmationResponse.pause) {
           dispatch(setPauseReasons(confirmationResponse.pause_reasons));
           return;

--- a/src/services/refact/chat.ts
+++ b/src/services/refact/chat.ts
@@ -144,6 +144,7 @@ export async function sendChat({
       // TODO: pass this through
       chat_mode: mode ?? "EXPLORE",
       // chat_mode: "EXPLORE", // NOTOOLS, EXPLORE, AGENT, CONFIGURE, PROJECTSUMMARY,
+      // TODO: not clear, that if we set integration.path it's going to be set also in meta as current_config_file
       ...(integration?.path ? { current_config_file: integration.path } : {}),
     },
   });

--- a/src/services/refact/tools.ts
+++ b/src/services/refact/tools.ts
@@ -1,7 +1,7 @@
 import { RootState } from "../../app/store";
 import { AT_TOOLS_AVAILABLE_URL, TOOLS_CHECK_CONFIRMATION } from "./consts";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
-import { ToolCall } from "./types";
+import { ChatMessage, ToolCall } from "./types";
 import { formatMessagesForLsp } from "../../features/Chat/Thread/utils";
 
 export const toolsApi = createApi({
@@ -47,13 +47,14 @@ export const toolsApi = createApi({
     }),
     checkForConfirmation: builder.mutation<
       ToolConfirmationResponse,
-      ToolCall[]
+      ToolConfirmationRequest
     >({
-      queryFn: async (tool_calls, api, _extraOptions, baseQuery) => {
+      queryFn: async (args, api, _extraOptions, baseQuery) => {
         const getState = api.getState as () => RootState;
         const state = getState();
         const port = state.config.lspPort;
-        const messages = state.chat.thread.messages;
+
+        const { messages, tool_calls } = args;
         const messagesForLsp = formatMessagesForLsp(messages);
 
         const url = `http://127.0.0.1:${port}${TOOLS_CHECK_CONFIRMATION}`;
@@ -116,6 +117,11 @@ export type ToolConfirmationPauseReason = {
 export type ToolConfirmationResponse = {
   pause: boolean;
   pause_reasons: ToolConfirmationPauseReason[];
+};
+
+export type ToolConfirmationRequest = {
+  tool_calls: ToolCall[];
+  messages: ChatMessage[];
 };
 
 function isToolCommand(tool: unknown): tool is ToolCommand {


### PR DESCRIPTION
# Fix: Better Tool Confirmation popup

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- [x] Resetting interacted and pause states of popup on `newChatAction`
- [x] Sending messages in `v1/tools-check-if-confirmation-needed` for better validation on the LSP side
- [x] Showing link to configure rules only if at least one `integr_config_path` is present in array of `pause_reasons` objects, otherwise no link is shown
- [x] Confirmation popup disappears on F1 hotkey hit.
- [Confirmation use real link to settings, no link if there's no config file](https://refact.fibery.io/Software_Development/Task/Confirmation-use-real-link-to-settings,-no-link-if-there's-no-config-file-654)
- [For Patch adjust confirmation: Expecting messages in /tools-check-if-confirmation-needed](https://refact.fibery.io/Software_Development/Task/For-Patch-adjust-confirmation-Expecting-messages-in-tools-check-if-confirmation-needed-658)
- [Conflict between confirmation and "assistant without tool calls, resume"](https://refact.fibery.io/Software_Development/Task/Conflict-between-confirmation-and-assistant-without-tool-calls,-resume-652)
- [Confirmation stays when hitting F1](https://refact.fibery.io/Software_Development/Task/Confirmation-stays-when-hitting-F1-653)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.