### PR TITLE
Feature: Automatic Patch switch

### DIFF
--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -10,7 +10,7 @@ import {
   useGetCapsQuery,
   useCapsForToolUse,
 } from "../../hooks";
-import type { Config } from "../../features/Config/configSlice";
+import { selectConfig, type Config } from "../../features/Config/configSlice";
 import {
   enableSend,
   selectIsStreaming,
@@ -43,6 +43,8 @@ export const Chat: React.FC<ChatProps> = ({
   const isStreaming = useAppSelector(selectIsStreaming);
   const isWaiting = useAppSelector(selectIsWaiting);
   const caps = useGetCapsQuery();
+
+  const config = useAppSelector(selectConfig);
 
   const chatId = useAppSelector(selectChatId);
   const { submit, abort, retryFromIndex } = useSendChatRequest();
@@ -126,7 +128,7 @@ export const Chat: React.FC<ChatProps> = ({
 
         <Flex justify="between" pl="1" pr="1" pt="1">
           {/* Two flexboxes are left for the future UI element on the right side */}
-          {messages.length > 0 && (
+          {messages.length > 0 && config.host === "web" && (
             <Flex align="center" justify="between" width="100%">
               <Flex align="center" gap="1">
                 <Text size="1">

--- a/src/components/ChatForm/ChatControls.tsx
+++ b/src/components/ChatForm/ChatControls.tsx
@@ -68,7 +68,7 @@ export const ApplyPatchSwitch: React.FC = () => {
             Disabled
           </Text>
           <Text as="p" size="2">
-            When disabled, Refact Agent will prompt you for confirmation before
+            When disabled, Refact Agent will ask for your confirmation before
             applying any unsaved changes.
           </Text>
         </HoverCard.Content>

--- a/src/components/ChatForm/ChatControls.tsx
+++ b/src/components/ChatForm/ChatControls.tsx
@@ -1,5 +1,13 @@
 import React, { useCallback, useMemo } from "react";
-import { Text, Flex, HoverCard, Link, Skeleton, Box } from "@radix-ui/themes";
+import {
+  Text,
+  Flex,
+  HoverCard,
+  Link,
+  Skeleton,
+  Box,
+  Switch,
+} from "@radix-ui/themes";
 import { Select } from "../Select";
 import { type Config } from "../../features/Config/configSlice";
 import { TruncateLeft } from "../Text";
@@ -12,12 +20,62 @@ import { useTourRefs } from "../../features/Tour";
 import { ToolUseSwitch } from "./ToolUseSwitch";
 import {
   ToolUse,
+  selectAutomaticPatch,
   selectIsStreaming,
+  selectIsWaiting,
   selectMessages,
   selectToolUse,
+  setAutomaticPatch,
   setToolUse,
 } from "../../features/Chat/Thread";
 import { useAppSelector, useAppDispatch, useCapsForToolUse } from "../../hooks";
+
+export const ApplyPatchSwitch: React.FC = () => {
+  const dispatch = useAppDispatch();
+  const isPatchAutomatic = useAppSelector(selectAutomaticPatch);
+
+  const handleAutomaticPatchChange = (checked: boolean) => {
+    dispatch(setAutomaticPatch(checked));
+  };
+
+  return (
+    <Flex
+      gap="2"
+      align="center"
+      wrap="wrap"
+      flexGrow="1"
+      flexShrink="0"
+      width="100%"
+    >
+      <Text size="2">Auto Apply Patch:</Text>
+      <Switch
+        size="1"
+        title="Enable/disable automatic patch calls by Agent"
+        checked={isPatchAutomatic}
+        onCheckedChange={handleAutomaticPatchChange}
+      />
+      <HoverCard.Root>
+        <HoverCard.Trigger>
+          <QuestionMarkCircledIcon style={{ marginLeft: 4 }} />
+        </HoverCard.Trigger>
+        <HoverCard.Content size="2" maxWidth="280px">
+          <Text weight="bold">Enabled</Text>
+          <Text as="p" size="2">
+            When enabled, Refact Agent will automatically apply changes to files
+            without asking for your confirmation.
+          </Text>
+          <Text as="div" mt="2" weight="bold">
+            Disabled
+          </Text>
+          <Text as="p" size="2">
+            When disabled, Refact Agent will prompt you for confirmation before
+            applying any unsaved changes.
+          </Text>
+        </HoverCard.Content>
+      </HoverCard.Root>
+    </Flex>
+  );
+};
 
 const CapsSelect: React.FC = () => {
   const refs = useTourRefs();
@@ -159,6 +217,7 @@ export const ChatControls: React.FC<ChatControlsProps> = ({
   const refs = useTourRefs();
   const dispatch = useAppDispatch();
   const isStreaming = useAppSelector(selectIsStreaming);
+  const isWaiting = useAppSelector(selectIsWaiting);
   const messages = useAppSelector(selectMessages);
   const toolUse = useAppSelector(selectToolUse);
   const onSetToolUse = useCallback(
@@ -167,8 +226,8 @@ export const ChatControls: React.FC<ChatControlsProps> = ({
   );
 
   const showControls = useMemo(
-    () => messages.length === 0 && !isStreaming,
-    [isStreaming, messages],
+    () => !isStreaming && !isWaiting,
+    [isStreaming, isWaiting],
   );
 
   return (
@@ -211,10 +270,12 @@ export const ChatControls: React.FC<ChatControlsProps> = ({
         />
       )}
 
-      <Flex gap="2" direction="column">
-        {showControls && <CapsSelect />}
-        {showControls && <PromptSelect />}
-      </Flex>
+      {showControls && (
+        <Flex gap="2" direction="column">
+          <CapsSelect />
+          {messages.length === 0 && <PromptSelect />}
+        </Flex>
+      )}
     </Flex>
   );
 };

--- a/src/components/ChatForm/ChatForm.tsx
+++ b/src/components/ChatForm/ChatForm.tsx
@@ -15,7 +15,7 @@ import {
 import { ErrorCallout, Callout } from "../Callout";
 import { ComboBox } from "../ComboBox";
 import { FilesPreview } from "./FilesPreview";
-import { ChatControls } from "./ChatControls";
+import { ApplyPatchSwitch, ChatControls } from "./ChatControls";
 import { addCheckboxValuesToInput } from "./utils";
 import { useCommandCompletionAndPreviewFiles } from "./useCommandCompletionAndPreviewFiles";
 import { useAppSelector, useAppDispatch } from "../../hooks";
@@ -37,6 +37,7 @@ import {
   selectIsStreaming,
   selectIsWaiting,
   selectMessages,
+  selectToolUse,
 } from "../../features/Chat";
 import { isAssistantMessage } from "../../services/refact/types";
 
@@ -55,6 +56,7 @@ export const ChatForm: React.FC<ChatFormProps> = ({
   const isStreaming = useAppSelector(selectIsStreaming);
   const isWaiting = useAppSelector(selectIsWaiting);
   const config = useConfig();
+  const toolUse = useAppSelector(selectToolUse);
   const error = useAppSelector(getErrorMessage);
   const information = useAppSelector(getInformationMessage);
   const pauseReasonsWithPause = useAppSelector(getPauseReasonsWithPauseStatus);
@@ -247,6 +249,11 @@ export const ChatForm: React.FC<ChatFormProps> = ({
         {helpInfo && (
           <Flex mb="3" direction="column">
             {helpInfo}
+          </Flex>
+        )}
+        {toolUse === "agent" && (
+          <Flex mb="2">
+            <ApplyPatchSwitch />
           </Flex>
         )}
         <Form

--- a/src/components/Markdown/Markdown.tsx
+++ b/src/components/Markdown/Markdown.tsx
@@ -34,7 +34,7 @@ import rehypeKatex from "rehype-katex";
 import remarkMath from "remark-math";
 import remarkGfm from "remark-gfm";
 import "katex/dist/katex.min.css";
-import { useLinksFromLsp, usePatchActions } from "../../hooks";
+import { useAppSelector, useLinksFromLsp, usePatchActions } from "../../hooks";
 
 import { ErrorCallout, DiffWarningCallout } from "../Callout";
 
@@ -44,6 +44,7 @@ import { extractFilePathFromPin } from "../../utils";
 import { telemetryApi } from "../../services/refact/telemetry";
 import { ChatLinkButton } from "../ChatLinks";
 import { extractLinkFromPuzzle } from "../../utils/extractLinkFromPuzzle";
+import { selectToolUse } from "../../features/Chat";
 
 export type MarkdownProps = Pick<
   React.ComponentProps<typeof ReactMarkdown>,
@@ -72,6 +73,8 @@ const PinMessages: React.FC<{
   } = usePatchActions();
   const [sendTelemetryEvent] =
     telemetryApi.useLazySendTelemetryChatEventQuery();
+
+  const toolUse = useAppSelector(selectToolUse);
 
   const getMarkdown = useCallback(() => {
     return (
@@ -147,22 +150,26 @@ const PinMessages: React.FC<{
           </Link>
         </TruncateLeft>{" "}
         <div style={{ flexGrow: 1 }} />
-        <Button
-          size="1"
-          onClick={(event) => handleAutoApply(event, children, filePath)}
-          disabled={disable}
-          title={`Show: ${children}`}
-        >
-          ➕ Auto Apply
-        </Button>
-        <Button
-          size="1"
-          onClick={onDiffClick}
-          disabled={disable || !hasMarkdown || !canPaste}
-          title="Replace the current selection in the ide."
-        >
-          ➕ Replace Selection
-        </Button>
+        {toolUse !== "agent" && (
+          <Flex gap="2">
+            <Button
+              size="1"
+              onClick={(event) => handleAutoApply(event, children, filePath)}
+              disabled={disable}
+              title={`Show: ${children}`}
+            >
+              ➕ Auto Apply
+            </Button>
+            <Button
+              size="1"
+              onClick={onDiffClick}
+              disabled={disable || !hasMarkdown || !canPaste}
+              title="Replace the current selection in the ide."
+            >
+              ➕ Replace Selection
+            </Button>
+          </Flex>
+        )}
       </Flex>
       {errorMessage && errorMessage.type === "error" && (
         <ErrorCallout onClick={resetErrorMessage} timeout={5000}>

--- a/src/features/Chat/Thread/actions.ts
+++ b/src/features/Chat/Thread/actions.ts
@@ -92,6 +92,10 @@ export const setPreventSend = createAction<PayloadWithId>(
 
 export const setToolUse = createAction<ToolUse>("chatThread/setToolUse");
 
+export const setAutomaticPatch = createAction<boolean>(
+  "chat/setAutomaticPatch",
+);
+
 export const saveTitle = createAction<PayloadWithIdAndTitle>(
   "chatThread/saveTitle",
 );

--- a/src/features/Chat/Thread/reducer.ts
+++ b/src/features/Chat/Thread/reducer.ts
@@ -29,6 +29,7 @@ import {
   setIntegrationData,
   setIsWaitingForResponse,
   setMaxNewTokens,
+  setAutomaticPatch,
 } from "./actions";
 import { formatChatResponse } from "./utils";
 import { DEFAULT_MAX_NEW_TOKENS } from "../../../services/refact";
@@ -156,6 +157,10 @@ export const chatReducer = createReducer(initialState, (builder) => {
     state.streaming = false;
     state.thread.read = true;
     state.prevent_send = false;
+  });
+
+  builder.addCase(setAutomaticPatch, (state, action) => {
+    state.automatic_patch = action.payload;
   });
 
   builder.addCase(chatAskedQuestion, (state, action) => {

--- a/src/features/Chat/Thread/selectors.ts
+++ b/src/features/Chat/Thread/selectors.ts
@@ -10,6 +10,8 @@ export const selectMessages = (state: RootState) => state.chat.thread.messages;
 export const selectToolUse = (state: RootState) => state.chat.tool_use;
 export const selectThreadToolUse = (state: RootState) =>
   state.chat.thread.tool_use;
+export const selectAutomaticPatch = (state: RootState) =>
+  state.chat.automatic_patch;
 export const selectIsWaiting = (state: RootState) =>
   state.chat.waiting_for_response;
 export const selectIsStreaming = (state: RootState) => state.chat.streaming;

--- a/src/features/Chat/Thread/types.ts
+++ b/src/features/Chat/Thread/types.ts
@@ -29,6 +29,7 @@ export type Chat = {
   thread: ChatThread;
   error: null | string;
   prevent_send: boolean;
+  automatic_patch?: boolean;
   waiting_for_response: boolean;
   max_new_tokens: number;
   cache: Record<string, ChatThread>;


### PR DESCRIPTION
# Feature: Automatic Patch switch

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- [x] Giving ability to switch tool_use and model even after messages being sent
- [x] Auto Apply Patch setting implementation (if auto apply set to true, on patch call no confirmation popup will appear)
- [x] Hiding old `model: <model_name> o mode: <tool_use>` UI except for web host
- [Patch confirmation UI: Autoconfirm/Manual](https://refact.fibery.io/Software_Development/Release-6.1-433#Task/Patch-confirmation-UI-Autoconfirm-Manual-664)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## Screenshots (if applicable)

<!-- If your changes include UI modifications, attach relevant screenshots here. -->

![Screenshot 2025-01-09 161231](https://github.com/user-attachments/assets/ac920632-74db-4019-ad4e-5e1f1b2d8f8d)

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.