### PR TITLE
Fix: Reasoning switch hiding in different from AGENT chat modes & better management of setting of a mode for a new chat

### DIFF
--- a/src/components/ChatForm/ChatControls.tsx
+++ b/src/components/ChatForm/ChatControls.tsx
@@ -138,20 +138,27 @@ export const AgentRollbackSwitch: React.FC = () => {
 };
 
 export const ReasoningModeSwitch: React.FC = () => {
+  const DEFAULT_MODE = "AGENT";
+  const ALLOWED_MODES_TO_DISPLAY_SWITCH = ["AGENT", "THINKING_AGENT"];
   const dispatch = useAppDispatch();
   const chatId = useAppSelector(selectChatId);
   const currentMode = useAppSelector(selectThreadMode);
-  const modeFromHistory =
-    useAppSelector((state) => getChatById(state, chatId), {
-      devModeChecks: { stabilityCheck: "never" },
-    })?.mode ?? "AGENT";
+  const modeFromHistory = useAppSelector(
+    (state) => getChatById(state, chatId)?.mode ?? DEFAULT_MODE,
+    { devModeChecks: { stabilityCheck: "never" } },
+  );
 
-  const isReasoningEnabled = useMemo(() => {
-    return currentMode === "THINKING_AGENT";
-  }, [currentMode]);
+  const isReasoningEnabled = currentMode === "THINKING_AGENT";
 
-  const handleDeepseekReasoningChange = (checked: boolean) => {
-    dispatch(setChatMode(checked ? "THINKING_AGENT" : modeFromHistory));
+  const handleReasoningModeChange = (checked: boolean) => {
+    // TODO: if default mode wasn't agent, but configure or project summary, what should we do?
+    const newMode = checked
+      ? "THINKING_AGENT"
+      : modeFromHistory === "THINKING_AGENT"
+        ? DEFAULT_MODE
+        : modeFromHistory;
+
+    dispatch(setChatMode(newMode));
   };
 
   const tooltipStyles: CSSProperties = {
@@ -159,6 +166,10 @@ export const ReasoningModeSwitch: React.FC = () => {
     visibility: "hidden",
     opacity: 0,
   };
+
+  if (currentMode && !ALLOWED_MODES_TO_DISPLAY_SWITCH.includes(currentMode)) {
+    return null;
+  }
 
   return (
     <Flex
@@ -176,7 +187,7 @@ export const ReasoningModeSwitch: React.FC = () => {
           size="1"
           title="Enable/disable deepseek-reasoner for Agent"
           checked={isReasoningEnabled}
-          onCheckedChange={handleDeepseekReasoningChange}
+          onCheckedChange={handleReasoningModeChange}
         />
         <QuestionMarkCircledIcon style={tooltipStyles} />
       </Flex>

--- a/src/features/History/historySlice.ts
+++ b/src/features/History/historySlice.ts
@@ -11,6 +11,7 @@ import {
   doneStreaming,
   removeChatFromCache,
   restoreChat,
+  setChatMode,
 } from "../Chat/Thread";
 import {
   isAssistantMessage,
@@ -270,6 +271,18 @@ startHistoryListening({
     if (chat.thread.id == action.payload.id && chat.streaming) return;
     if (action.payload.id in chat.cache) return;
     listenerApi.dispatch(markChatAsRead(action.payload.id));
+  },
+});
+
+startHistoryListening({
+  actionCreator: setChatMode,
+  effect: (action, listenerApi) => {
+    const state = listenerApi.getState();
+    const thread = state.chat.thread;
+    if (!(thread.id in state.history)) return;
+
+    const toSave = { ...thread, mode: action.payload };
+    listenerApi.dispatch(saveChat(toSave));
   },
 });
 


### PR DESCRIPTION
# Fix: Reasoning switch hiding in different from AGENT chat modes & better management of setting of a mode for a new chat

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- What was the problem?
- How did you solve it?
- [Can't turn off reasoning slider in existing chat](https://refact.fibery.io/Software_Development/Task/Can't-turn-off-reasoning-slider-in-existing-chat-818)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.