### PR TITLE
fix(callout retry loop):

### DIFF
--- a/src/components/ChatForm/ChatForm.tsx
+++ b/src/components/ChatForm/ChatForm.tsx
@@ -15,7 +15,6 @@ import {
   useIsOnline,
   useConfig,
   useAgentUsage,
-  useSendChatRequest,
   useCapsForToolUse,
   USAGE_LIMIT_EXHAUSTED_MESSAGE,
 } from "../../hooks";
@@ -50,7 +49,7 @@ import {
   selectThreadToolUse,
   selectToolUse,
 } from "../../features/Chat";
-import { isUserMessage, telemetryApi } from "../../services/refact";
+import { telemetryApi } from "../../services/refact";
 import { push } from "../../features/Pages/pagesSlice";
 import { AgentCapabilities } from "./AgentCapabilities";
 
@@ -70,7 +69,6 @@ export const ChatForm: React.FC<ChatFormProps> = ({
   const dispatch = useAppDispatch();
   const isStreaming = useAppSelector(selectIsStreaming);
   const isWaiting = useAppSelector(selectIsWaiting);
-  const { retryFromIndex } = useSendChatRequest();
   const { isMultimodalitySupportedForCurrentModel } = useCapsForToolUse();
   const config = useConfig();
   const toolUse = useAppSelector(selectToolUse);
@@ -90,22 +88,7 @@ export const ChatForm: React.FC<ChatFormProps> = ({
     return threadToolUse === "agent" && toolUse === "agent";
   }, [toolUse, threadToolUse]);
 
-  const onClearError = useCallback(() => {
-    dispatch(clearError());
-    const userMessages = messages.filter(isUserMessage);
-
-    // getting second-to-last user message
-    const lastSuccessfulUserMessage =
-      userMessages.slice(-2, -1)[0] || userMessages[0];
-
-    const lastSuccessfulUserMessageIndex = messages.indexOf(
-      lastSuccessfulUserMessage,
-    );
-    retryFromIndex(
-      lastSuccessfulUserMessageIndex,
-      lastSuccessfulUserMessage.content,
-    );
-  }, [dispatch, retryFromIndex, messages]);
+  const onClearError = useCallback(() => dispatch(clearError()), [dispatch]);
 
   const caps = useCapsForToolUse();
 

--- a/src/features/Chat/Thread/actions.ts
+++ b/src/features/Chat/Thread/actions.ts
@@ -127,6 +127,10 @@ export const setMaxNewTokens = createAction<number>(
   "chatThread/setMaxNewTokens",
 );
 
+export const fixBrokenToolMessages = createAction<PayloadWithId>(
+  "chatThread/fixBrokenToolMessages",
+);
+
 // TODO: This is the circular dep when imported from hooks :/
 const createAppAsyncThunk = createAsyncThunk.withTypes<{
   state: RootState;
@@ -318,7 +322,10 @@ export const chatAskQuestionThunk = createAppAsyncThunk<
         }
         const reader = response.body?.getReader();
         if (!reader) return;
-        const onAbort = () => thunkAPI.dispatch(setPreventSend({ id: chatId }));
+        const onAbort = () => {
+          thunkAPI.dispatch(setPreventSend({ id: chatId }));
+          thunkAPI.dispatch(fixBrokenToolMessages({ id: chatId }));
+        };
         const onChunk = (json: Record<string, unknown>) => {
           const action = chatResponse({
             ...(json as ChatResponse),
@@ -332,6 +339,7 @@ export const chatAskQuestionThunk = createAppAsyncThunk<
         // console.log("Catch called");
         thunkAPI.dispatch(doneStreaming({ id: chatId }));
         thunkAPI.dispatch(chatError({ id: chatId, message: err.message }));
+        thunkAPI.dispatch(fixBrokenToolMessages({ id: chatId }));
         return thunkAPI.rejectWithValue(err.message);
       })
       .finally(() => {

--- a/src/features/Chat/Thread/reducer.ts
+++ b/src/features/Chat/Thread/reducer.ts
@@ -32,9 +32,14 @@ import {
   setAutomaticPatch,
   setLastUserMessageId,
   setEnabledCheckpoints,
+  fixBrokenToolMessages,
 } from "./actions";
 import { formatChatResponse } from "./utils";
-import { DEFAULT_MAX_NEW_TOKENS } from "../../../services/refact";
+import {
+  DEFAULT_MAX_NEW_TOKENS,
+  isToolCallMessage,
+  validateToolCall,
+} from "../../../services/refact";
 
 const createChatThread = (
   tool_use: ToolUse,
@@ -293,5 +298,17 @@ export const chatReducer = createReducer(initialState, (builder) => {
 
   builder.addCase(setMaxNewTokens, (state, action) => {
     state.max_new_tokens = action.payload;
+  });
+
+  builder.addCase(fixBrokenToolMessages, (state, action) => {
+    if (action.payload.id !== state.thread.id) return state;
+    if (state.thread.messages.length === 0) return state;
+    const lastMessage = state.thread.messages[state.thread.messages.length - 1];
+    if (!isToolCallMessage(lastMessage)) return state;
+    if (lastMessage.tool_calls.every(validateToolCall)) return state;
+    const validToolCalls = lastMessage.tool_calls.filter(validateToolCall);
+    const messages = state.thread.messages.slice(0, -1);
+    const newMessage = { ...lastMessage, tool_calls: validToolCalls };
+    state.thread.messages = [...messages, newMessage];
   });
 });

--- a/src/services/refact/types.ts
+++ b/src/services/refact/types.ts
@@ -47,6 +47,16 @@ function isToolCall(call: unknown): call is ToolCall {
   return true;
 }
 
+export const validateToolCall = (toolCall: ToolCall) => {
+  if (!isToolCall(toolCall)) return false;
+  try {
+    JSON.parse(toolCall.function.arguments);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 type ToolContent = string | MultiModalToolContent[];
 
 export function isToolContent(json: unknown): json is ToolContent {


### PR DESCRIPTION
# Fix retry loop


## Description

Issue when using an invalid integration causes chat to respond with a 400, this creates a loop when dismissing the error callout.

Removing the call, also highlighted the need to validate the tool_calls in the assistant message to prevent errors where the tool call isn't complete.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->

- Step 1: Use an invalid integration file (service_storybook)
- Step 2: send a chat
- Step 3: dismiss the error.
- the error callout should not block / loop the user.

## Screenshots (if applicable)


## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.

## Linked Issues

https://refact.fibery.io/Software_Development/Sprint-2025-02-10-495#Task/Bug---When-press-Click-to-retry-last-message-is-deleted-and-last-but-one-message-is-re-requested-824

## Additional Notes

<!-- Any additional information that might be useful during the review process. -->
