### PR TITLE
ui: hide uncommitted changes warning when the info or error callout i…

### DIFF
--- a/src/components/ChatLinks/UncommittedChangesWarning.tsx
+++ b/src/components/ChatLinks/UncommittedChangesWarning.tsx
@@ -3,13 +3,22 @@ import { useAppSelector, useGetLinksFromLsp } from "../../hooks";
 import { Markdown } from "../Markdown";
 import { Flex, Separator } from "@radix-ui/themes";
 import { selectIsStreaming, selectIsWaiting } from "../../features/Chat";
+import { getErrorMessage } from "../../features/Errors/errorsSlice";
+import { getInformationMessage } from "../../features/Errors/informationSlice";
 
 export const UncommittedChangesWarning: React.FC = () => {
   const isStreaming = useAppSelector(selectIsStreaming);
   const isWaiting = useAppSelector(selectIsWaiting);
   const linksRequest = useGetLinksFromLsp();
+  const error = useAppSelector(getErrorMessage);
+  const information = useAppSelector(getInformationMessage);
+
+  const hasCallout = React.useMemo(() => {
+    return !!error || !!information;
+  }, [error, information]);
 
   if (
+    hasCallout ||
     isStreaming ||
     isWaiting ||
     linksRequest.isFetching ||


### PR DESCRIPTION
# hide uncommitted changes warning when the info or error callout is dislayed.


## Description


- What was the problem?
- How did you solve it?
- Any background context or related links?

## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test


- Step 1: Have uncommitted changes, Cause an error
- Step 2: The uncommitted changes warning should not be visible.
- ...



![Screenshot description](url/to/screenshot.png)

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.

## Linked Issues


## Additional Notes

